### PR TITLE
fixed __get_login_session 504 gateway timeout

### DIFF
--- a/custom_components/carelink/api.py
+++ b/custom_components/carelink/api.py
@@ -92,14 +92,8 @@ class CarelinkClient:
 
         self._async_client = None
         self._cookies = None
-        self.__common_headers = {
-            # Common browser headers
-            "Accept-Language": "en;q=0.9, *;q=0.8",
-            "Connection": "keep-alive",
-            "sec-ch-ua": '"Google Chrome";v="87", " Not;A Brand";v="99", "Chromium";v="87"',
-            "User-Agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/87.0.4280.88 Safari/537.36",
-            "Accept": "text/html,application/xhtml+xml,application/xml;q=0.9,image/avif,image/webp,image/apng,*/*;q=0.8,application/signed-exchange;v=b3;q=0.9",
-        }
+        self.__common_headers = {}
+
 
     @property
     def async_client(self):


### PR DESCRIPTION
I had the same issue that was reported by other users [Cant sign-in #38 ](https://github.com/yo-han/Home-Assistant-Carelink/issues/38)
The configuration window of the integration was showing username/password issues.

After some tesing I was able to pass the login sequence by deleting the predefined common headers in api.py.

Seems like there is no other change required. 
Would be nice if someone could cross check...
BR
