### PR TITLE
use auth token 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -152,3 +152,4 @@ cython_debug/
 #.idea/
 
 *.DS_Store
+cookies.txt

--- a/README.md
+++ b/README.md
@@ -26,9 +26,15 @@ Copy the `custom_components/carelink` to your `custom_components` folder. Reboot
 
 [![Open your Home Assistant instance and start setting up a new integration.](https://my.home-assistant.io/badges/config_flow_start.svg)](https://my.home-assistant.io/redirect/config_flow_start/?domain=carelink)
 
-### Integration Login
+### Integration Setup
 
-Login with your Carelink credentials and enter the two digit country code in the country field.
+## Session Token
+In order to authenticate to the Carelink server, the Carelink client needs a valid access token. This can be obtained by manually logging into a Carelink follower account via Carelink web page. After successful login, the access token (plus country code) can be shown and copied using the Cookie Quick Manager Firefox plugin as follows:
+
+- With the Carelink web page still active, open Cookie Quick Manger from the extensions menu
+- Select option "Search Cookies: carelink.minimed.eu"
+- Copy value of auth temp token and use it as Session token for initial setup of the Homeassistant Carelink integration 
+
 
 ### Enable debug logging
 

--- a/custom_components/carelink/__init__.py
+++ b/custom_components/carelink/__init__.py
@@ -7,7 +7,7 @@ import re
 from datetime import datetime, timedelta
 from zoneinfo import ZoneInfo
 from homeassistant.config_entries import ConfigEntry
-from homeassistant.const import CONF_PASSWORD, CONF_USERNAME, Platform
+from homeassistant.const import Platform
 from homeassistant.util.dt import DEFAULT_TIME_ZONE
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.update_coordinator import (
@@ -99,10 +99,9 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
         patientId = config["patientId"]
 
     carelink_client = CarelinkClient(
-        config[CONF_USERNAME],
-        config[CONF_PASSWORD],
         config["country"],
-        patientId,
+        config["token"],
+        patientId
     )
 
     hass.data.setdefault(DOMAIN, {})[entry.entry_id] = {CLIENT: carelink_client}

--- a/custom_components/carelink/api.py
+++ b/custom_components/carelink/api.py
@@ -48,7 +48,7 @@ CARELINK_AUTH_TOKEN_COOKIE_NAME = "auth_tmp_token"
 CARELINK_TOKEN_VALIDTO_COOKIE_NAME = "c_token_valid_to"
 AUTH_EXPIRE_DEADLINE_MINUTES = 10
 
-CON_CONTEXT_COOKIE = "cookies.txt"
+CON_CONTEXT_COOKIE = "custom_components/carelink/cookies.txt"
 
 DEBUG = False
 
@@ -131,12 +131,6 @@ class CarelinkClient:
             if self.__carelink_country == "us"
             else CARELINK_CONNECT_SERVER_EU
         )
-
-    def __extract_response_data(self, response_body, begstr, endstr):
-        """Return a clean stripped response_body by using begstr and endstr."""
-        beg = response_body.find(begstr) + len(begstr)
-        end = response_body.find(endstr, beg)
-        return response_body[beg:end].strip('"')
 
     async def fetch_async(self, url, headers, params=None):
         """Perform an async get request."""
@@ -244,7 +238,6 @@ class CarelinkClient:
         )
 
     # Old last24hours webapp data
-
     async def __get_last24_hours(self):
         printdbg("__get_last24_hours")
         query_params = {
@@ -257,7 +250,6 @@ class CarelinkClient:
         )
 
     # Periodic data from CareLink Cloud
-
     async def __get_connect_display_message(
         self, username, role, endpoint_url, patient_id=None
     ):
@@ -406,7 +398,6 @@ class CarelinkClient:
                         file.write(self.__carelink_auth_token)
                         printdbg("Saving new token to cookies.txt")
                 except:
-                    # Refresh failed, manual login needed
                     printdbg("Failed to store refreshed token")
                 printdbg("New token is valid until " + self.__auth_token_validto)
             else:

--- a/custom_components/carelink/config_flow.py
+++ b/custom_components/carelink/config_flow.py
@@ -18,9 +18,8 @@ _LOGGER = logging.getLogger(__name__)
 
 STEP_USER_DATA_SCHEMA = vol.Schema(
     {
-        vol.Required("username"): str,
-        vol.Required("password"): str,
         vol.Required("country"): str,
+        vol.Required("token"): str,
         vol.Optional("patientId"): str,
     }
 )
@@ -37,7 +36,7 @@ async def validate_input(hass: HomeAssistant, data: dict[str, Any]) -> dict[str,
         patient_id = data["patientId"]
 
     client = CarelinkClient(
-        data["username"], data["password"], data["country"], patient_id
+        data["country"], data["token"], patient_id
     )
 
     if not await client.login():

--- a/custom_components/carelink/strings.json
+++ b/custom_components/carelink/strings.json
@@ -4,11 +4,10 @@
     "step": {
       "user": {
         "title": "Setup your Carelink account",
-        "description": "Provide your username and password. Please ensure that you enter the 2-letter ISO code corresponding to the country in which your account was registered. If you are logging in with a Carelink Care Partner account, please include the patient ID, which should be the username of the main Carelink account.",
+        "description": "Provide your session token. Please ensure that you enter the 2-letter ISO code corresponding to the country in which your account was registered. If you are logging in with a Carelink Care Partner account, please include the patient ID, which should be the username of the main Carelink account.",
         "data": {
-          "username": "[%key:common::config_flow::data::username%]",
-          "password": "[%key:common::config_flow::data::password%]",
           "country": "[%key:common::config_flow::data::country%]",
+          "token": "[%key:common::config_flow::data::token%]",
           "patientId": "[%key:common::config_flow::data::patientId%]"
         }
       }

--- a/custom_components/carelink/translations/de.json
+++ b/custom_components/carelink/translations/de.json
@@ -11,7 +11,7 @@
     "step": {
       "user": {
         "title": "Konfigurieren Sie Ihr Carelink-Konto",
-        "description": "Geben Sie Ihren Benutzernamen und Ihr Passwort ein. Stellen Sie sicher, dass Sie den 2-Buchstaben-ISO-Code eingeben, der dem Land entspricht, in dem Ihr Konto registriert ist. Wenn Sie sich mit einem Carelink Care Partner-Konto anmelden, geben Sie bitte die Patienten-ID an. Diese sollte der Benutzername des primären Carelink-Kontos sein.",
+        "description": "Geben Sie Ihren Session Token ein. Stellen Sie sicher, dass Sie den 2-Buchstaben-ISO-Code eingeben, der dem Land entspricht, in dem Ihr Konto registriert ist. Wenn Sie sich mit einem Carelink Care Partner-Konto anmelden, geben Sie bitte die Patienten-ID an. Diese sollte der Benutzername des primären Carelink-Kontos sein.",
         "data": {
           "token": "Session Token",
           "country": "Land",

--- a/custom_components/carelink/translations/de.json
+++ b/custom_components/carelink/translations/de.json
@@ -5,7 +5,7 @@
     },
     "error": {
       "cannot_connect": "Verbindung fehlgeschlagen",
-      "invalid_auth": "Ungültiger Benutzername und/oder Passwort",
+      "invalid_auth": "Ungültiger Token",
       "unknown": "Unerwartetes Problem"
     },
     "step": {
@@ -13,9 +13,8 @@
         "title": "Konfigurieren Sie Ihr Carelink-Konto",
         "description": "Geben Sie Ihren Benutzernamen und Ihr Passwort ein. Stellen Sie sicher, dass Sie den 2-Buchstaben-ISO-Code eingeben, der dem Land entspricht, in dem Ihr Konto registriert ist. Wenn Sie sich mit einem Carelink Care Partner-Konto anmelden, geben Sie bitte die Patienten-ID an. Diese sollte der Benutzername des primären Carelink-Kontos sein.",
         "data": {
+          "token": "Session Token",
           "country": "Land",
-          "password": "Passwort",
-          "username": "Benutzername",
           "patientId": "Patienten-ID (optional)"
         }
       }

--- a/custom_components/carelink/translations/en.json
+++ b/custom_components/carelink/translations/en.json
@@ -11,11 +11,10 @@
         "step": {
             "user": {
                 "title": "Setup your Carelink account",
-                "description": "Provide your username and password. Please ensure that you enter the 2-letter ISO code corresponding to the country in which your account was registered. If you are logging in with a Carelink Care Partner account, please include the patient ID, which should be the username of the main Carelink account.",
+                "description": "Provide your session token. Please ensure that you enter the 2-letter ISO code corresponding to the country in which your account was registered. If you are logging in with a Carelink Care Partner account, please include the patient ID, which should be the username of the main Carelink account.",
                 "data": {
                     "country": "Country",
-                    "password": "Password",
-                    "username": "Username",
+                    "token": "Session Token",
                     "patientId": "Patient ID (Optional)"
                 }
             }

--- a/custom_components/carelink/translations/fr.json
+++ b/custom_components/carelink/translations/fr.json
@@ -1,24 +1,23 @@
 {
     "config": {
-    "abort": {
-    "already_configured": "L'appareil est déjà configuré"
-    },
-    "error": {
-    "cannot_connect": "Échec de la connexion",
-    "invalid_auth": "Nom d'utilisateur et/ou mot de passe invalide(s)",
-    "unknown": "Problème inattendu"
-    },
-    "step": {
-    "user": {
-    "title": "Configurez votre compte Carelink",
-    "description": "Veuillez entrer votre nom d'utilisateur et votre mot de passe. Assurez-vous d'entrer le code ISO à deux lettres correspondant au pays dans lequel votre compte est enregistré. Si vous vous connectez avec un compte Carelink Care Partner, veuillez indiquer l'ID du patient, qui doit être le nom d'utilisateur du compte Carelink principal.",
-    "data": {
-    "country": "Pays",
-    "password": "Mot de passe",
-    "username": "Nom d'utilisateur",
-    "patientId": "ID patient (facultatif)"
+        "abort": {
+            "already_configured": "L'appareil est déjà configuré"
+        },
+        "error": {
+            "cannot_connect": "Échec de la connexion",
+            "invalid_auth": "Nom d'utilisateur et/ou mot de passe invalide(s)",
+            "unknown": "Problème inattendu"
+        },
+        "step": {
+            "user": {
+                "title": "Configurez votre compte Carelink",
+                "description": "Veuillez entrer votre nom d'utilisateur et votre mot de passe. Assurez-vous d'entrer le code ISO à deux lettres correspondant au pays dans lequel votre compte est enregistré. Si vous vous connectez avec un compte Carelink Care Partner, veuillez indiquer l'ID du patient, qui doit être le nom d'utilisateur du compte Carelink principal.",
+                "data": {
+                    "country": "Pays",
+                    "token": "Session Token",
+                    "patientId": "ID patient (facultatif)"
+                }
+            }
+        }
     }
-    }
-    }
-    }
-    }
+}

--- a/custom_components/carelink/translations/nl.json
+++ b/custom_components/carelink/translations/nl.json
@@ -14,8 +14,7 @@
                 "description": "Geef uw gebruikersnaam en wachtwoord op. Zorg ervoor dat u de 2-letterige ISO-code invoert die overeenkomt met het land waarin uw account is geregistreerd. Als u zich aanmeldt met een Carelink Care Partner-account, vermeld dan de patiënt-ID, dit moet de gebruikersnaam zijn van het primaire Carelink-account.",
                 "data": {
                     "country": "Land",
-                    "password": "Wachtwoord",
-                    "username": "Gebruikersnaam",
+                    "token": "Session Token",
                     "patientId": "Patient ID (Optioneel)"
                 }
             }


### PR DESCRIPTION
Merged in the latest changes from Ondrej.
Adapted the integration setup, no need for user/password anymore.
Initial setup requires auth token from Carelink portal. See Ondrej readme -> [Ondrej Inital Token](https://github.com/ondrej1024/carelink-python-client#token-file)
Instead "saving domain to file" in ondrejs description, we only need to value of the auth_tmp_token from the details view as parameter for initial setup.
New implementation requires to use a sperate carelink follower account, otherwise the account will keep logging off from other applications. 
Implemented persistent storage of (new) cookie to survive a home assistant reset (if it does not take longer than 10 mins).
Implementation will refresh token 10 min before expire (token should last for 40 min once refreshed).

Merry Christmas :) 
