### PR TITLE
Fix reservoir amount in Nightscout uploader

### DIFF
--- a/custom_components/carelink/nightscout_uploader.py
+++ b/custom_components/carelink/nightscout_uploader.py
@@ -356,7 +356,7 @@ class NightscoutUploader:
                 battery=dict(
                     status=rawdata["conduitBatteryStatus"],
                     voltage=rawdata["conduitBatteryLevel"]),
-                reservoir=rawdata["activeInsulin"]["amount"],
+                reservoir=rawdata["reservoirRemainingUnits"],
                 status=dict(
                     status=rawdata["systemStatusMessage"],
                     suspended=rawdata["medicalDeviceSuspended"])))]


### PR DESCRIPTION
fixes #88

Change the reservoir amount to use `rawdata["reservoirRemainingUnits"]` instead of `rawdata["activeInsulin"]["amount"]`.

* Modify `custom_components/carelink/nightscout_uploader.py` to update the `reservoir` parameter.
* Update the `__getDeviceStatus` method to reflect this change.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/yo-han/Home-Assistant-Carelink/pull/89?shareId=951c8693-8c27-4544-95cb-9b078e4fb78e).