### PR TITLE
fix: carelink config url update

### DIFF
--- a/custom_components/carelink/api.py
+++ b/custom_components/carelink/api.py
@@ -41,7 +41,7 @@ VERSION = "0.4"
 # Constants
 AUTH_EXPIRE_DEADLINE_MINUTES = 10
 CON_CONTEXT_AUTH = "custom_components/carelink/logindata.json"
-CARELINK_CONFIG_URL = "https://clcloud.minimed.com/connect/carepartner/v6/discover/android/3.1"
+CARELINK_CONFIG_URL = "https://clcloud.minimed.eu/connect/carepartner/v11/discover/android/3.1"
 AUTH_ERROR_CODES = [401,403]
 
 DEBUG = False


### PR DESCRIPTION
Fixes #87 as proposed in https://github.com/ondrej1024/carelink-python-client/issues/26

This pull request includes a change to the `custom_components/carelink/api.py` file to update the CareLink configuration URL. This change ensures that the application points to the correct endpoint for the CareLink service.

* [`custom_components/carelink/api.py`](diffhunk://#diff-62bd65562f19136bd9c658bfd928e0e95b9c21fc0589552364149ddc8f7960d5L44-R44): Updated `CARELINK_CONFIG_URL` to use the new endpoint "https://clcloud.minimed.eu/connect/carepartner/v11/discover/android/3.1".https://github.com/ondrej1024/carelink-python-client/issues/26