### PR TITLE
Potential fix for code scanning alert no. 4: Clear-text logging of sensitive information

### DIFF
--- a/utils/carelink_carepartner_api_login.py
+++ b/utils/carelink_carepartner_api_login.py
@@ -177,7 +177,7 @@ def do_login(endpoint_config):
 	captcha_url = providers["providers"][0]["provider"]["auth_url"]
 
 	# step 3 captcha login and consent
-	print(f"captcha url: {captcha_url}")
+	print("captcha url received")  # Omit sensitive details from logs
 	captcha_code, captcha_sso_state = do_captcha(captcha_url, sso_config["oauth"]["client"]["client_ids"][0]['redirect_uri'])
 	print(f"sso state after captcha: {captcha_sso_state}")
 


### PR DESCRIPTION
Potential fix for [https://github.com/yo-han/Home-Assistant-Carelink/security/code-scanning/4](https://github.com/yo-han/Home-Assistant-Carelink/security/code-scanning/4)

To fix this problem, we need to avoid logging sensitive data in cleartext. Specifically, we must ensure that `captcha_url` is not directly output to the logs, as it may contain sensitive query parameters or tokens. The best approach is to remove or redact this logging statement. If logging is genuinely needed for debugging, it is much safer to log only non-sensitive parts, such as the domain or path portion of the URL, excluding any query strings or tokens.

Therefore, in the region of concern (line 180), the print statement should either be removed entirely or replaced with a safer alternative—logging only non-sensitive components (e.g., just `'captcha url received'` or the base path without query or fragment information).

No new imports are necessary unless you decide to parse URLs to strip sensitive query strings (for example, using Python's built-in `urllib.parse`). However, in security-sensitive code, the safest option is often simply not to log at all.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
