### PR TITLE
Potential fix for code scanning alert no. 6: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/hassfest.yml
+++ b/.github/workflows/hassfest.yml
@@ -1,4 +1,6 @@
 name: Validate with hassfest
+permissions:
+  contents: read
 
 on:
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/yo-han/Home-Assistant-Carelink/security/code-scanning/6](https://github.com/yo-han/Home-Assistant-Carelink/security/code-scanning/6)

To fix the problem, add an explicit `permissions` key to the workflow—either at the root (to apply to all jobs unless overridden) or directly within jobs as needed. Since this workflow only checks out code and runs `hassfest` without creating or modifying issues, pull requests, or any repo contents, it is safe and optimal to assign `contents: read`—the minimal required permission. Place `permissions: contents: read` at the top level, right after the `name` and before the `on:` key, in `.github/workflows/hassfest.yml`.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
