### PR TITLE
Potential fix for code scanning alert no. 5: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -1,4 +1,6 @@
 name: Validate
+permissions:
+  contents: read
 
 on:
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/yo-han/Home-Assistant-Carelink/security/code-scanning/5](https://github.com/yo-han/Home-Assistant-Carelink/security/code-scanning/5)

To fix the problem, you should explicitly specify the minimum required permissions by adding a `permissions` block at the workflow or job level in `.github/workflows/validate.yml`. As this workflow only appears to require read access (for `actions/checkout` and reading contents), the minimal starting point is to set `contents: read`. This can be done at the top level, immediately after `name`, or under the `jobs.validate` key if job-specific permissions are preferred. The simplest and clearest solution is to add the `permissions:` key at the root level, directly after the `name` line.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
