### PR TITLE
Add Docker-based token tool for easier setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,16 +37,15 @@ The Home Assistant Carelink Integration needs the initial login data stored in t
 
 The easiest way to get your `logindata.json` is using our Docker-based token tool. This requires only Docker - no Python or other dependencies needed.
 
-1. Navigate to the token-tool folder and edit `docker-compose.yml` with your credentials:
-   ```yaml
-   environment:
-     - CARELINK_USERNAME=your@email.com
-     - CARELINK_PASSWORD=yourpassword
+1. Navigate to the token-tool folder and set up your credentials:
+   ```bash
+   cd token-tool
+   cp .env.example .env
+   # Edit .env with your Carelink username and password
    ```
 
 2. Run the tool:
    ```bash
-   cd token-tool
    docker compose up --build
    ```
 

--- a/README.md
+++ b/README.md
@@ -31,12 +31,42 @@ Copy the `custom_components/carelink` to your `custom_components` folder. Reboot
 ### Carelink Login Data
 The needed information for the authentification process can either be provided as file (=logindata.json), or entered during the initial setup of the integration.
 #### Get the data
-The Home Assistant Carelink Integration needs the initial login data stored in the `logindata.json` file. This file can be created **by running the login script on a PC with a screen**.
+The Home Assistant Carelink Integration needs the initial login data stored in the `logindata.json` file. There are two ways to create this file:
+
+##### Option 1: Docker Token Tool (Recommended)
+
+The easiest way to get your `logindata.json` is using our Docker-based token tool. This requires only Docker - no Python or other dependencies needed.
+
+1. Navigate to the token-tool folder and edit `docker-compose.yml` with your credentials:
+   ```yaml
+   environment:
+     - CARELINK_USERNAME=your@email.com
+     - CARELINK_PASSWORD=yourpassword
+   ```
+
+2. Run the tool:
+   ```bash
+   cd token-tool
+   docker compose up --build
+   ```
+
+3. Open `http://localhost:6080/vnc.html?autoconnect=true` in your browser
+
+4. **Wait a few seconds** for your credentials to be auto-filled, then solve the CAPTCHA
+
+5. Download your token file from `http://localhost:8000/logindata.json` or find it in `./token-tool/output/`
+
+For more details and troubleshooting, see the [Token Tool README](token-tool/README.md).
+
+##### Option 2: Python Script
+
+Alternatively, you can run the login script directly on a PC with a screen.
 The login script from [@ondrej1024](https://github.com/ondrej1024)'s Carelink Python API, written by @palmarci (Pal Marci), was slightly modified and can be found here ["carelink_carepartner_api_login.py"](https://github.com/yo-han/Home-Assistant-Carelink/blob/develop/utils/carelink_carepartner_api_login.py).
 
 Simply run:
+
 ```
-python carelink_carepartner_api_login.py 
+python carelink_carepartner_api_login.py
 ```
 
 You might need to install the following Python packages to satisfy the script's dependencies:

--- a/token-tool/.env.example
+++ b/token-tool/.env.example
@@ -1,7 +1,7 @@
 # Carelink Token Tool Configuration
 # Copy this file to .env and fill in your values
 
-# Set to "--us" for US region, leave empty for EU
+# Set to "us" for US region, leave empty for EU
 CARELINK_REGION=
 
 # Optional: pre-fill your credentials (you still need to solve CAPTCHA)

--- a/token-tool/.env.example
+++ b/token-tool/.env.example
@@ -1,0 +1,9 @@
+# Carelink Token Tool Configuration
+# Copy this file to .env and fill in your values
+
+# Set to "--us" for US region, leave empty for EU
+CARELINK_REGION=
+
+# Optional: pre-fill your credentials (you still need to solve CAPTCHA)
+CARELINK_USERNAME=
+CARELINK_PASSWORD=

--- a/token-tool/.gitignore
+++ b/token-tool/.gitignore
@@ -1,0 +1,4 @@
+# Don't commit sensitive token data
+output/logindata.json
+output/*.json
+!output/.gitkeep

--- a/token-tool/.gitignore
+++ b/token-tool/.gitignore
@@ -1,4 +1,5 @@
-# Don't commit sensitive token data
+# Don't commit sensitive data
+.env
 output/logindata.json
 output/*.json
 !output/.gitkeep

--- a/token-tool/Dockerfile
+++ b/token-tool/Dockerfile
@@ -1,0 +1,60 @@
+FROM python:3.11-slim-bookworm
+
+# Install system dependencies
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    firefox-esr \
+    wget \
+    curl \
+    gnupg \
+    xvfb \
+    x11vnc \
+    novnc \
+    websockify \
+    supervisor \
+    procps \
+    autocutsel \
+    xclip \
+    && rm -rf /var/lib/apt/lists/*
+
+# Install geckodriver - detect architecture
+ARG GECKODRIVER_VERSION=v0.35.0
+RUN ARCH=$(dpkg --print-architecture) && \
+    if [ "$ARCH" = "amd64" ]; then GECKO_ARCH="linux64"; \
+    elif [ "$ARCH" = "arm64" ]; then GECKO_ARCH="linux-aarch64"; \
+    else echo "Unsupported architecture: $ARCH" && exit 1; fi && \
+    echo "Installing geckodriver ${GECKODRIVER_VERSION} for ${GECKO_ARCH}" && \
+    wget -q "https://github.com/mozilla/geckodriver/releases/download/${GECKODRIVER_VERSION}/geckodriver-${GECKODRIVER_VERSION}-${GECKO_ARCH}.tar.gz" -O /tmp/geckodriver.tar.gz && \
+    tar -xzf /tmp/geckodriver.tar.gz -C /usr/local/bin/ && \
+    rm /tmp/geckodriver.tar.gz && \
+    chmod +x /usr/local/bin/geckodriver && \
+    geckodriver --version
+
+# Install Python dependencies
+RUN pip install --no-cache-dir \
+    requests \
+    pyOpenSSL \
+    selenium-wire \
+    curlify \
+    blinker==1.7.0
+
+# Create app directory
+WORKDIR /app
+
+# Copy the login script
+COPY carelink_login.py /app/
+COPY start.sh /app/
+COPY supervisord.conf /etc/supervisor/conf.d/supervisord.conf
+
+# Create output directory
+RUN mkdir -p /output
+
+# Set permissions
+RUN chmod +x /app/start.sh
+
+# Expose noVNC port and file server port
+EXPOSE 6080 8000
+
+# Set display
+ENV DISPLAY=:99
+
+CMD ["/usr/bin/supervisord", "-c", "/etc/supervisor/conf.d/supervisord.conf"]

--- a/token-tool/Dockerfile
+++ b/token-tool/Dockerfile
@@ -1,5 +1,8 @@
 FROM python:3.11-slim-bookworm
 
+LABEL org.opencontainers.image.source="https://github.com/yo-han/Home-Assistant-Carelink"
+LABEL org.opencontainers.image.description="Carelink Token Tool - obtain login tokens for Home Assistant Carelink integration"
+
 # Install system dependencies
 RUN apt-get update && apt-get install -y --no-install-recommends \
     firefox-esr \
@@ -29,12 +32,12 @@ RUN ARCH=$(dpkg --print-architecture) && \
     chmod +x /usr/local/bin/geckodriver && \
     geckodriver --version
 
-# Install Python dependencies
+# Install Python dependencies (pinned versions for reproducibility)
 RUN pip install --no-cache-dir \
-    requests \
-    pyOpenSSL \
-    selenium-wire \
-    curlify \
+    requests==2.31.0 \
+    pyOpenSSL==24.0.0 \
+    selenium-wire==5.1.0 \
+    curlify==2.2.1 \
     blinker==1.7.0
 
 # Create app directory
@@ -56,5 +59,9 @@ EXPOSE 6080 8000
 
 # Set display
 ENV DISPLAY=:99
+
+# Health check
+HEALTHCHECK --interval=30s --timeout=10s --start-period=10s --retries=3 \
+    CMD curl -f http://localhost:6080/ || exit 1
 
 CMD ["/usr/bin/supervisord", "-c", "/etc/supervisor/conf.d/supervisord.conf"]

--- a/token-tool/README.md
+++ b/token-tool/README.md
@@ -56,7 +56,7 @@ Open `http://localhost:6080/vnc.html?autoconnect=true` and enter credentials man
 For **US region**, add to your `.env` file:
 
 ```bash
-CARELINK_REGION=--us
+CARELINK_REGION=us
 ```
 
 ## Docker Commands

--- a/token-tool/README.md
+++ b/token-tool/README.md
@@ -11,15 +11,20 @@ A Docker-based tool to easily obtain your Carelink login tokens for the Home Ass
 
 ### Option 1: With auto-fill credentials (Recommended)
 
-Edit `docker-compose.yml` and add your credentials:
+1. Copy the example environment file and add your credentials:
 
-```yaml
-environment:
-  - CARELINK_USERNAME=your@email.com
-  - CARELINK_PASSWORD=yourpassword
+```bash
+cp .env.example .env
 ```
 
-Then run:
+2. Edit `.env` with your credentials:
+
+```bash
+CARELINK_USERNAME=your@email.com
+CARELINK_PASSWORD=yourpassword
+```
+
+3. Run the tool:
 
 ```bash
 docker compose up --build
@@ -48,11 +53,10 @@ Open `http://localhost:6080/vnc.html?autoconnect=true` and enter credentials man
 
 ## Region Selection
 
-For **US region**, set the environment variable:
+For **US region**, add to your `.env` file:
 
-```yaml
-environment:
-  - CARELINK_REGION=--us
+```bash
+CARELINK_REGION=--us
 ```
 
 ## Docker Commands
@@ -83,8 +87,9 @@ docker compose logs -f
 - Check terminal output for error messages
 - Make sure you completed the login including CAPTCHA
 
-## Security Note
+## Security
 
-- Your credentials are only used locally within the Docker container
+- **Credentials are stored locally** in your `.env` file (which is gitignored)
+- **Ports are bound to localhost only** - not accessible from other devices on your network
 - The `logindata.json` contains sensitive tokens - keep it secure
-- Consider removing credentials from `docker-compose.yml` after use
+- Delete your `.env` file after obtaining your tokens if desired

--- a/token-tool/README.md
+++ b/token-tool/README.md
@@ -1,0 +1,90 @@
+# Carelink Token Tool
+
+A Docker-based tool to easily obtain your Carelink login tokens for the Home Assistant Carelink integration.
+
+## Requirements
+
+- Docker installed on your computer
+- A Carelink account (patient or follower)
+
+## Quick Start
+
+### Option 1: With auto-fill credentials (Recommended)
+
+Edit `docker-compose.yml` and add your credentials:
+
+```yaml
+environment:
+  - CARELINK_USERNAME=your@email.com
+  - CARELINK_PASSWORD=yourpassword
+```
+
+Then run:
+
+```bash
+docker compose up --build
+```
+
+Your credentials will be auto-filled - you only need to solve the CAPTCHA!
+
+**Note:** The auto-fill has a few seconds delay after the page loads. Wait for the fields to be filled before clicking anything.
+
+### Option 2: Manual entry
+
+```bash
+docker compose up --build
+```
+
+Open `http://localhost:6080/vnc.html?autoconnect=true` and enter credentials manually.
+
+## Usage
+
+1. **Start the container**
+2. **Open your browser**: `http://localhost:6080/vnc.html?autoconnect=true`
+3. **Wait a few seconds** for credentials to be auto-filled (if configured)
+4. **Solve the CAPTCHA** and complete the login
+5. **Download your tokens**: `http://localhost:8000/logindata.json` (or find in `./output/`)
+6. **Copy to Home Assistant**: Place `logindata.json` in `custom_components/carelink/`
+
+## Region Selection
+
+For **US region**, set the environment variable:
+
+```yaml
+environment:
+  - CARELINK_REGION=--us
+```
+
+## Docker Commands
+
+```bash
+# Start
+docker compose up --build
+
+# Stop
+docker compose down
+
+# View logs
+docker compose logs -f
+```
+
+## Troubleshooting
+
+### Login fails
+- Make sure MFA is **disabled** on your Carelink account
+- Try using a follower/care partner account
+- Check that you're using the correct region (EU vs US)
+
+### Browser doesn't appear
+- Wait a few seconds for the container to start
+- Refresh the noVNC page
+
+### Token file not created
+- Check terminal output for error messages
+- Make sure you completed the login including CAPTCHA
+
+## Security Note
+
+- Your credentials are only used locally within the Docker container
+- The `logindata.json` contains sensitive tokens - keep it secure
+- Consider removing credentials from `docker-compose.yml` after use

--- a/token-tool/carelink_login.py
+++ b/token-tool/carelink_login.py
@@ -18,6 +18,7 @@ import re
 import string
 import uuid
 import secrets
+import time
 from time import sleep
 import sys
 
@@ -26,6 +27,11 @@ import OpenSSL
 from seleniumwire import webdriver
 from selenium.webdriver.firefox.options import Options
 from selenium.webdriver.firefox.service import Service
+from selenium.common.exceptions import NoSuchElementException
+
+# Configuration
+REQUEST_TIMEOUT = 30  # seconds
+LOGIN_TIMEOUT = 600   # 10 minutes max wait for user to complete login
 
 
 def random_b64_str(length):
@@ -89,6 +95,7 @@ def do_captcha(url, redirect_url):
         print("  2. Solve the CAPTCHA")
         print("  3. Complete the login")
     print("\nWaiting for login to complete...")
+    print(f"(Timeout: {LOGIN_TIMEOUT // 60} minutes)")
     print("=" * 50 + "\n")
 
     # Configure Firefox for container environment
@@ -121,7 +128,6 @@ def do_captcha(url, redirect_url):
     if has_credentials:
         try:
             sleep(3)  # Wait for page to load
-            # Try common username field selectors
             username_filled = False
             password_filled = False
 
@@ -133,9 +139,9 @@ def do_captcha(url, redirect_url):
                     elem.clear()
                     elem.send_keys(username)
                     username_filled = True
-                    print(f"Username auto-filled")
+                    print("Username auto-filled")
                     break
-                except:
+                except NoSuchElementException:
                     continue
 
             sleep(0.5)
@@ -147,9 +153,9 @@ def do_captcha(url, redirect_url):
                     elem.clear()
                     elem.send_keys(password)
                     password_filled = True
-                    print(f"Password auto-filled")
+                    print("Password auto-filled")
                     break
-                except:
+                except NoSuchElementException:
                     continue
 
             if username_filled and password_filled:
@@ -160,26 +166,38 @@ def do_captcha(url, redirect_url):
             print(f"\nAuto-fill failed: {e}")
             print("Please enter credentials manually.")
 
+    # Wait for login with timeout
+    start_time = time.time()
     while True:
+        # Check timeout
+        if time.time() - start_time > LOGIN_TIMEOUT:
+            driver.quit()
+            raise Exception(f"Login timeout - no successful login within {LOGIN_TIMEOUT // 60} minutes")
+
         for request in driver.requests:
             if request.response:
                 if request.response.status_code == 302:
                     if "location" in request.response.headers:
                         location = request.response.headers["location"]
                         if redirect_url in location:
-                            code = re.search(r"code=(.*)", location).group(1)
-                            state = None
-                            if "state=" in location:
-                                state = re.search(r"state=(.*)", location).group(1)
-                            print("\nLogin successful! Closing browser...")
-                            driver.quit()
-                            return (code, state)
+                            # Use more specific regex to avoid capturing extra params
+                            code_match = re.search(r"code=([^&]+)", location)
+                            if code_match:
+                                code = code_match.group(1)
+                                state = None
+                                state_match = re.search(r"state=([^&]+)", location)
+                                if state_match:
+                                    state = state_match.group(1)
+                                print("\nLogin successful! Closing browser...")
+                                driver.quit()
+                                return (code, state)
         sleep(0.1)
 
 
 def resolve_endpoint_config(discovery_url, is_us_region=False):
     print(f"Discovering endpoint configuration (Region: {'US' if is_us_region else 'EU'})...")
-    discover_resp = json.loads(requests.get(discovery_url).text)
+    response = requests.get(discovery_url, timeout=REQUEST_TIMEOUT)
+    discover_resp = json.loads(response.text)
     sso_url = None
     is_auth0 = False
 
@@ -198,7 +216,8 @@ def resolve_endpoint_config(discovery_url, is_us_region=False):
     if sso_url is None:
         raise Exception("Could not get SSO config url")
 
-    sso_config = json.loads(requests.get(sso_url).text)
+    sso_response = requests.get(sso_url, timeout=REQUEST_TIMEOUT)
+    sso_config = json.loads(sso_response.text)
     api_base_url = f"https://{sso_config['server']['hostname']}:{sso_config['server']['port']}/{sso_config['server']['prefix']}"
     if api_base_url.endswith('/'):
         api_base_url = api_base_url[:-1]
@@ -228,7 +247,7 @@ def do_login_non_auth0(endpoint_config, logindata_file, rsa_keysize):
         'device-id': base64.b64encode(random_device_id().encode()).decode()
     }
     client_init_url = api_base_url + sso_config["mag"]["system_endpoints"]["client_credential_init_endpoint_path"]
-    client_init_req = requests.post(client_init_url, data=data, headers=headers)
+    client_init_req = requests.post(client_init_url, data=data, headers=headers, timeout=REQUEST_TIMEOUT)
     client_init_response = json.loads(client_init_req.text)
 
     # Step 2: Prepare authorization
@@ -251,7 +270,8 @@ def do_login_non_auth0(endpoint_config, logindata_file, rsa_keysize):
         'state': client_state
     }
     authorize_url = api_base_url + sso_config["oauth"]["system_endpoints"]["authorization_endpoint_path"]
-    providers = json.loads(requests.get(authorize_url, params=auth_params).text)
+    auth_response = requests.get(authorize_url, params=auth_params, timeout=REQUEST_TIMEOUT)
+    providers = json.loads(auth_response.text)
     captcha_url = providers["providers"][0]["provider"]["auth_url"]
 
     # Step 3: Browser login
@@ -290,7 +310,7 @@ def do_login_non_auth0(endpoint_config, logindata_file, rsa_keysize):
     }
     csr = reformat_csr(csr)
     reg_url = api_base_url + sso_config["mag"]["system_endpoints"]["device_register_endpoint_path"]
-    reg_req = requests.post(reg_url, headers=reg_headers, data=csr)
+    reg_req = requests.post(reg_url, headers=reg_headers, data=csr, timeout=REQUEST_TIMEOUT)
 
     if reg_req.status_code != 200:
         error_desc = json.loads(reg_req.text).get("error_description", "Unknown error")
@@ -308,7 +328,8 @@ def do_login_non_auth0(endpoint_config, logindata_file, rsa_keysize):
     token_req = requests.post(
         token_req_url,
         headers={"mag-identifier": reg_req.headers["mag-identifier"]},
-        data=token_req_data
+        data=token_req_data,
+        timeout=REQUEST_TIMEOUT
     )
 
     if token_req.status_code != 200:
@@ -353,7 +374,7 @@ def do_login_auth0(endpoint_config, logindata_file):
         "code": captcha_code,
         "redirect_uri": sso_config["client"]["redirect_uri"],
     }
-    token_req = requests.post(token_req_url, data=token_req_data)
+    token_req = requests.post(token_req_url, data=token_req_data, timeout=REQUEST_TIMEOUT)
 
     if token_req.status_code != 200:
         print(f"Error response: {token_req.text}")
@@ -380,7 +401,8 @@ def do_login(endpoint_config, logindata_file, rsa_keysize):
 def read_data_file(file):
     if os.path.isfile(file):
         try:
-            token_data = json.loads(open(file, "r").read())
+            with open(file, "r") as f:
+                token_data = json.load(f)
             required_fields = ["access_token", "refresh_token", "client_id"]
             for field in required_fields:
                 if field not in token_data:
@@ -405,8 +427,9 @@ def main():
                         default=False, action='store_true')
     args = parser.parse_args()
 
-    # Also check environment variable
-    is_us_region = args.us or os.environ.get('CARELINK_REGION', '').lower() == '--us'
+    # Also check environment variable (support multiple formats)
+    region_env = os.environ.get('CARELINK_REGION', '').lower().strip()
+    is_us_region = args.us or region_env in ('--us', 'us', 'true', '1')
 
     print("\n" + "=" * 50)
     print("   CARELINK TOKEN TOOL")

--- a/token-tool/carelink_login.py
+++ b/token-tool/carelink_login.py
@@ -1,0 +1,443 @@
+#!/usr/bin/env python3
+###############################################################################
+#
+#  Carelink Token Tool - Docker Edition
+#
+#  Based on the original carelink_carepartner_api_login.py by @palmarci
+#  Modified for use in a Docker container with noVNC
+#
+###############################################################################
+
+import argparse
+import base64
+import hashlib
+import json
+import os
+import random
+import re
+import string
+import uuid
+import secrets
+from time import sleep
+import sys
+
+import requests
+import OpenSSL
+from seleniumwire import webdriver
+from selenium.webdriver.firefox.options import Options
+from selenium.webdriver.firefox.service import Service
+
+
+def random_b64_str(length):
+    random_chars = ''.join(random.choice(string.ascii_letters + string.digits) for _ in range(length + 10))
+    base64_string = base64.b64encode(random_chars.encode('utf-8')).decode('utf-8')
+    return base64_string[:length]
+
+
+def random_uuid():
+    return str(uuid.UUID(bytes=secrets.token_bytes(16)))
+
+
+def random_android_model():
+    models = ['SM-G973F', "SM-G988U1", "SM-G981W", "SM-G9600"]
+    random.shuffle(models)
+    return models[0]
+
+
+def random_device_id():
+    return hashlib.sha256(os.urandom(40)).hexdigest()
+
+
+def create_csr(keypair, cn, ou, dc, o):
+    req = OpenSSL.crypto.X509Req()
+    req.get_subject().CN = cn
+    req.get_subject().OU = ou
+    req.get_subject().DC = dc
+    req.get_subject().O = o
+    req.set_pubkey(keypair)
+    req.sign(keypair, 'sha256')
+    csr = OpenSSL.crypto.dump_certificate_request(OpenSSL.crypto.FILETYPE_PEM, req)
+    return csr
+
+
+def reformat_csr(csr):
+    csr = csr.decode()
+    csr = csr.replace("\n", "")
+    csr = csr.replace("-----BEGIN CERTIFICATE REQUEST-----", "")
+    csr = csr.replace("-----END CERTIFICATE REQUEST-----", "")
+    csr_raw = base64.b64decode(csr.encode())
+    csr = base64.urlsafe_b64encode(csr_raw).decode()
+    return csr
+
+
+def do_captcha(url, redirect_url):
+    # Check for pre-filled credentials
+    username = os.environ.get('CARELINK_USERNAME', '')
+    password = os.environ.get('CARELINK_PASSWORD', '')
+    has_credentials = bool(username and password)
+
+    print("\n" + "=" * 50)
+    print("BROWSER OPENING")
+    print("=" * 50)
+    print("\nPlease go to your browser window (noVNC tab)")
+    if has_credentials:
+        print("\nCredentials will be auto-filled!")
+        print("You only need to solve the CAPTCHA.")
+    else:
+        print("\nComplete the following steps:")
+        print("  1. Enter your Carelink credentials")
+        print("  2. Solve the CAPTCHA")
+        print("  3. Complete the login")
+    print("\nWaiting for login to complete...")
+    print("=" * 50 + "\n")
+
+    # Configure Firefox for container environment
+    options = Options()
+    options.set_preference("browser.tabs.warnOnClose", False)
+    options.set_preference("browser.sessionstore.resume_from_crash", False)
+
+    # Configure geckodriver service
+    service = Service(
+        executable_path="/usr/local/bin/geckodriver",
+        log_output="/dev/null"
+    )
+
+    # Use seleniumwire options
+    seleniumwire_options = {
+        'disable_encoding': True
+    }
+
+    driver = webdriver.Firefox(
+        service=service,
+        options=options,
+        seleniumwire_options=seleniumwire_options
+    )
+
+    # Maximize window for better visibility in noVNC
+    driver.maximize_window()
+    driver.get(url)
+
+    # Auto-fill credentials if provided
+    if has_credentials:
+        try:
+            sleep(3)  # Wait for page to load
+            # Try common username field selectors
+            username_filled = False
+            password_filled = False
+
+            for selector in ['#username', '#email', 'input[name="username"]',
+                           'input[name="email"]', 'input[type="email"]',
+                           'input[name="loginfmt"]', '#loginfmt']:
+                try:
+                    elem = driver.find_element("css selector", selector)
+                    elem.clear()
+                    elem.send_keys(username)
+                    username_filled = True
+                    print(f"Username auto-filled")
+                    break
+                except:
+                    continue
+
+            sleep(0.5)
+
+            for selector in ['#password', 'input[name="password"]',
+                           'input[type="password"]', '#passwd']:
+                try:
+                    elem = driver.find_element("css selector", selector)
+                    elem.clear()
+                    elem.send_keys(password)
+                    password_filled = True
+                    print(f"Password auto-filled")
+                    break
+                except:
+                    continue
+
+            if username_filled and password_filled:
+                print("\nCredentials filled! Please solve the CAPTCHA.")
+            else:
+                print("\nCould not auto-fill all fields. Please enter manually.")
+        except Exception as e:
+            print(f"\nAuto-fill failed: {e}")
+            print("Please enter credentials manually.")
+
+    while True:
+        for request in driver.requests:
+            if request.response:
+                if request.response.status_code == 302:
+                    if "location" in request.response.headers:
+                        location = request.response.headers["location"]
+                        if redirect_url in location:
+                            code = re.search(r"code=(.*)", location).group(1)
+                            state = None
+                            if "state=" in location:
+                                state = re.search(r"state=(.*)", location).group(1)
+                            print("\nLogin successful! Closing browser...")
+                            driver.quit()
+                            return (code, state)
+        sleep(0.1)
+
+
+def resolve_endpoint_config(discovery_url, is_us_region=False):
+    print(f"Discovering endpoint configuration (Region: {'US' if is_us_region else 'EU'})...")
+    discover_resp = json.loads(requests.get(discovery_url).text)
+    sso_url = None
+    is_auth0 = False
+
+    for c in discover_resp["CP"]:
+        if c['region'].lower() == "us" and is_us_region:
+            key = c['UseSSOConfiguration']
+            sso_url = c[key]
+            if "Auth0" in key:
+                is_auth0 = True
+        elif c['region'].lower() == "eu" and not is_us_region:
+            key = c['UseSSOConfiguration']
+            sso_url = c[key]
+            if "Auth0" in key:
+                is_auth0 = True
+
+    if sso_url is None:
+        raise Exception("Could not get SSO config url")
+
+    sso_config = json.loads(requests.get(sso_url).text)
+    api_base_url = f"https://{sso_config['server']['hostname']}:{sso_config['server']['port']}/{sso_config['server']['prefix']}"
+    if api_base_url.endswith('/'):
+        api_base_url = api_base_url[:-1]
+
+    print(f"Found endpoint: {api_base_url}")
+    print(f"Authentication type: {'Auth0' if is_auth0 else 'Standard'}")
+
+    return sso_config, api_base_url, is_auth0
+
+
+def write_datafile(obj, filename):
+    with open(filename, 'w') as f:
+        json.dump(obj, f, indent=4)
+    print(f"\nToken data saved to: {filename}")
+
+
+def do_login_non_auth0(endpoint_config, logindata_file, rsa_keysize):
+    sso_config, api_base_url, is_auth0 = endpoint_config
+
+    # Step 1: Initialize client
+    print("\nStep 1/4: Initializing client...")
+    data = {
+        'client_id': sso_config['oauth']['client']['client_ids'][0]['client_id'],
+        "nonce": random_uuid()
+    }
+    headers = {
+        'device-id': base64.b64encode(random_device_id().encode()).decode()
+    }
+    client_init_url = api_base_url + sso_config["mag"]["system_endpoints"]["client_credential_init_endpoint_path"]
+    client_init_req = requests.post(client_init_url, data=data, headers=headers)
+    client_init_response = json.loads(client_init_req.text)
+
+    # Step 2: Prepare authorization
+    print("Step 2/4: Preparing authorization...")
+    client_code_verifier = base64.urlsafe_b64encode(os.urandom(40)).decode('utf-8')
+    client_code_verifier = re.sub('[^a-zA-Z0-9]+', '', client_code_verifier)
+    client_code_challange = hashlib.sha256(client_code_verifier.encode('utf-8')).digest()
+    client_code_challange = base64.urlsafe_b64encode(client_code_challange).decode('utf-8')
+    client_code_challange = client_code_challange.replace('=', '')
+
+    client_state = random_b64_str(22)
+    auth_params = {
+        'client_id': client_init_response["client_id"],
+        'response_type': 'code',
+        'display': 'social_login',
+        'scope': sso_config["oauth"]["client"]["client_ids"][0]['scope'],
+        'redirect_uri': sso_config["oauth"]["client"]["client_ids"][0]['redirect_uri'],
+        'code_challenge': client_code_challange,
+        'code_challenge_method': 'S256',
+        'state': client_state
+    }
+    authorize_url = api_base_url + sso_config["oauth"]["system_endpoints"]["authorization_endpoint_path"]
+    providers = json.loads(requests.get(authorize_url, params=auth_params).text)
+    captcha_url = providers["providers"][0]["provider"]["auth_url"]
+
+    # Step 3: Browser login
+    print("Step 3/4: Browser login required...")
+    captcha_code, captcha_sso_state = do_captcha(
+        captcha_url,
+        sso_config["oauth"]["client"]["client_ids"][0]['redirect_uri']
+    )
+
+    # Step 4: Device registration
+    print("Step 4/4: Registering device and obtaining tokens...")
+    register_device_id = random_device_id()
+    client_auth_str = f"{client_init_response['client_id']}:{client_init_response['client_secret']}"
+
+    android_model = random_android_model()
+    android_model_safe = re.sub(r"[^a-zA-Z0-9]", "", android_model)
+    keypair = OpenSSL.crypto.PKey()
+    keypair.generate_key(OpenSSL.crypto.TYPE_RSA, rsa_keysize)
+    csr = create_csr(
+        keypair,
+        "socialLogin",
+        register_device_id,
+        android_model_safe,
+        sso_config["oauth"]["client"]["organization"]
+    )
+
+    reg_headers = {
+        'device-name': base64.b64encode(android_model.encode()).decode(),
+        'authorization': f"Bearer {captcha_code}",
+        'cert-format': 'pem',
+        'client-authorization': "Basic " + base64.b64encode(client_auth_str.encode()).decode(),
+        'create-session': 'true',
+        'code-verifier': client_code_verifier,
+        'device-id': base64.b64encode(register_device_id.encode()).decode(),
+        "redirect-uri": sso_config["oauth"]["client"]["client_ids"][0]['redirect_uri']
+    }
+    csr = reformat_csr(csr)
+    reg_url = api_base_url + sso_config["mag"]["system_endpoints"]["device_register_endpoint_path"]
+    reg_req = requests.post(reg_url, headers=reg_headers, data=csr)
+
+    if reg_req.status_code != 200:
+        error_desc = json.loads(reg_req.text).get("error_description", "Unknown error")
+        raise Exception(f'Could not register device: {error_desc}')
+
+    # Get token
+    token_req_url = api_base_url + sso_config["oauth"]["system_endpoints"]["token_endpoint_path"]
+    token_req_data = {
+        "assertion": reg_req.headers["id-token"],
+        "client_id": client_init_response['client_id'],
+        "client_secret": client_init_response['client_secret'],
+        'scope': sso_config["oauth"]["client"]["client_ids"][0]['scope'],
+        "grant_type": reg_req.headers["id-token-type"]
+    }
+    token_req = requests.post(
+        token_req_url,
+        headers={"mag-identifier": reg_req.headers["mag-identifier"]},
+        data=token_req_data
+    )
+
+    if token_req.status_code != 200:
+        raise Exception("Could not get token data from server")
+
+    token_data = json.loads(token_req.text)
+    token_data["client_id"] = token_req_data["client_id"]
+    token_data["client_secret"] = token_req_data["client_secret"]
+    del token_data["expires_in"]
+    del token_data["token_type"]
+    token_data["mag-identifier"] = reg_req.headers["mag-identifier"]
+
+    write_datafile(token_data, logindata_file)
+    return token_data
+
+
+def do_login_auth0(endpoint_config, logindata_file):
+    sso_config, api_base_url, is_auth0 = endpoint_config
+
+    print("\nStep 1/2: Preparing authorization...")
+    auth_params = {
+        'client_id': sso_config['client']['client_id'],
+        'response_type': 'code',
+        'scope': sso_config["client"]["scope"],
+        'redirect_uri': sso_config["client"]['redirect_uri'],
+        'audience': sso_config["client"]["audience"]
+    }
+    authorize_url = api_base_url + sso_config["system_endpoints"]["authorization_endpoint_path"]
+    captcha_url = f"{authorize_url}?{'&'.join(f'{key}={value}' for key, value in auth_params.items())}"
+
+    print("Step 2/2: Browser login required...")
+    captcha_code, captcha_sso_state = do_captcha(
+        captcha_url,
+        sso_config["client"]["redirect_uri"]
+    )
+
+    print("\nExchanging code for tokens...")
+    token_req_url = api_base_url + sso_config["system_endpoints"]["token_endpoint_path"]
+    token_req_data = {
+        "grant_type": "authorization_code",
+        "client_id": sso_config["client"]["client_id"],
+        "code": captcha_code,
+        "redirect_uri": sso_config["client"]["redirect_uri"],
+    }
+    token_req = requests.post(token_req_url, data=token_req_data)
+
+    if token_req.status_code != 200:
+        print(f"Error response: {token_req.text}")
+        raise Exception("Could not get token data from server")
+
+    token_data = json.loads(token_req.text)
+    token_data["client_id"] = token_req_data["client_id"]
+    del token_data["expires_in"]
+    del token_data["token_type"]
+
+    write_datafile(token_data, logindata_file)
+    return token_data
+
+
+def do_login(endpoint_config, logindata_file, rsa_keysize):
+    sso_config, api_base_url, is_auth0 = endpoint_config
+
+    if is_auth0:
+        return do_login_auth0(endpoint_config, logindata_file)
+    else:
+        return do_login_non_auth0(endpoint_config, logindata_file, rsa_keysize)
+
+
+def read_data_file(file):
+    if os.path.isfile(file):
+        try:
+            token_data = json.loads(open(file, "r").read())
+            required_fields = ["access_token", "refresh_token", "client_id"]
+            for field in required_fields:
+                if field not in token_data:
+                    print(f"Warning: Field '{field}' is missing from existing data file")
+                    return None
+            return token_data
+        except json.JSONDecodeError:
+            print("Warning: Could not parse existing data file")
+            return None
+    return None
+
+
+def main():
+    # Configuration
+    logindata_file = 'logindata.json'
+    discovery_url = 'https://clcloud.minimed.eu/connect/carepartner/v13/discover/android/3.6'
+    rsa_keysize = 2048
+
+    # Parse command line / environment
+    parser = argparse.ArgumentParser(description='Carelink Token Tool')
+    parser.add_argument('--us', help='Use US region (default: EU)',
+                        default=False, action='store_true')
+    args = parser.parse_args()
+
+    # Also check environment variable
+    is_us_region = args.us or os.environ.get('CARELINK_REGION', '').lower() == '--us'
+
+    print("\n" + "=" * 50)
+    print("   CARELINK TOKEN TOOL")
+    print("=" * 50)
+    print(f"\nRegion: {'United States' if is_us_region else 'Europe'}")
+    print(f"Output: {os.path.abspath(logindata_file)}")
+
+    # Check for existing token file
+    token_data = read_data_file(logindata_file)
+
+    if token_data is not None:
+        print("\nExisting token file found!")
+        print("Delete logindata.json to generate new tokens.")
+        return
+
+    print("\nStarting login process...")
+
+    try:
+        endpoint_config = resolve_endpoint_config(discovery_url, is_us_region=is_us_region)
+        token_data = do_login(endpoint_config, logindata_file, rsa_keysize)
+        print("\n" + "=" * 50)
+        print("   LOGIN SUCCESSFUL!")
+        print("=" * 50)
+    except Exception as e:
+        print("\n" + "=" * 50)
+        print("   LOGIN FAILED")
+        print("=" * 50)
+        print(f"\nError: {str(e)}")
+        print("\nPlease try again or check your credentials.")
+        sys.exit(1)
+
+
+if __name__ == "__main__":
+    main()

--- a/token-tool/docker-compose.yml
+++ b/token-tool/docker-compose.yml
@@ -4,15 +4,12 @@ services:
     image: carelink-token-tool:latest
     container_name: carelink-token-tool
     ports:
-      - "6080:6080"
-      - "8000:8000"
+      # Bind to localhost only for security
+      - "127.0.0.1:6080:6080"
+      - "127.0.0.1:8000:8000"
     volumes:
       - ./output:/output
-    environment:
-      # Set to "--us" for US region, leave empty for EU
-      - CARELINK_REGION=
-      # Optional: pre-fill your credentials (you still need to solve CAPTCHA)
-      - CARELINK_USERNAME=
-      - CARELINK_PASSWORD=
+    env_file:
+      - .env
     # Needed for browser rendering
     shm_size: "2gb"

--- a/token-tool/docker-compose.yml
+++ b/token-tool/docker-compose.yml
@@ -1,0 +1,18 @@
+services:
+  carelink-token-tool:
+    build: .
+    image: carelink-token-tool:latest
+    container_name: carelink-token-tool
+    ports:
+      - "6080:6080"
+      - "8000:8000"
+    volumes:
+      - ./output:/output
+    environment:
+      # Set to "--us" for US region, leave empty for EU
+      - CARELINK_REGION=
+      # Optional: pre-fill your credentials (you still need to solve CAPTCHA)
+      - CARELINK_USERNAME=
+      - CARELINK_PASSWORD=
+    # Needed for browser rendering
+    shm_size: "2gb"

--- a/token-tool/start.sh
+++ b/token-tool/start.sh
@@ -29,8 +29,8 @@ echo ""
 # Change to output directory so logindata.json is saved there
 cd /output
 
-# Run the login script
-python /app/carelink_login.py "$CARELINK_REGION"
+# Run the login script (reads CARELINK_REGION from environment)
+python /app/carelink_login.py
 LOGIN_RESULT=$?
 
 echo ""

--- a/token-tool/start.sh
+++ b/token-tool/start.sh
@@ -1,0 +1,63 @@
+#!/bin/bash
+
+echo ""
+echo "=============================================="
+echo "   Carelink Token Tool"
+echo "=============================================="
+echo ""
+echo "1. Open browser for login:"
+echo "   http://localhost:6080/vnc.html?autoconnect=true"
+echo ""
+echo "2. Copy/paste tip: use the clipboard panel"
+echo "   (click arrow on the left side)"
+echo ""
+echo "=============================================="
+echo ""
+
+# Wait for X server to be ready
+sleep 3
+
+# Wait for noVNC to be ready
+while ! curl -s http://localhost:6080 > /dev/null 2>&1; do
+    echo "Waiting for noVNC to start..."
+    sleep 1
+done
+
+echo "noVNC is ready! Opening browser..."
+echo ""
+
+# Change to output directory so logindata.json is saved there
+cd /output
+
+# Run the login script
+python /app/carelink_login.py $CARELINK_REGION
+LOGIN_RESULT=$?
+
+echo ""
+echo "=============================================="
+
+if [ -f /output/logindata.json ]; then
+    echo ""
+    echo "  SUCCESS!"
+    echo ""
+    echo "  Download your token file:"
+    echo "  http://localhost:8000/logindata.json"
+    echo ""
+    echo "  Or find it in: ./output/logindata.json"
+    echo ""
+    echo "=============================================="
+else
+    echo ""
+    echo "  LOGIN FAILED"
+    echo ""
+    echo "  Please check the browser window for errors."
+    echo ""
+    echo "=============================================="
+fi
+
+echo ""
+echo "Press Ctrl+C to stop the container"
+echo ""
+
+# Keep container running so user can download the file
+tail -f /dev/null

--- a/token-tool/start.sh
+++ b/token-tool/start.sh
@@ -30,7 +30,7 @@ echo ""
 cd /output
 
 # Run the login script
-python /app/carelink_login.py $CARELINK_REGION
+python /app/carelink_login.py "$CARELINK_REGION"
 LOGIN_RESULT=$?
 
 echo ""

--- a/token-tool/supervisord.conf
+++ b/token-tool/supervisord.conf
@@ -1,0 +1,41 @@
+[supervisord]
+nodaemon=true
+logfile=/var/log/supervisor/supervisord.log
+pidfile=/var/run/supervisord.pid
+user=root
+
+[program:xvfb]
+command=/usr/bin/Xvfb :99 -screen 0 1280x800x24
+autorestart=true
+priority=100
+
+[program:x11vnc]
+command=/usr/bin/x11vnc -display :99 -forever -shared -rfbport 5900 -nopw
+autorestart=true
+priority=200
+
+[program:novnc]
+command=/usr/share/novnc/utils/novnc_proxy --vnc localhost:5900 --listen 6080
+autorestart=true
+priority=300
+
+[program:autocutsel]
+command=/usr/bin/autocutsel -s CLIPBOARD -fork
+environment=DISPLAY=":99"
+autorestart=true
+priority=350
+
+[program:fileserver]
+command=python -m http.server 8000 --directory /output
+autorestart=true
+priority=360
+
+[program:carelink-login]
+command=/app/start.sh
+autorestart=false
+priority=400
+startretries=0
+stdout_logfile=/dev/stdout
+stdout_logfile_maxbytes=0
+stderr_logfile=/dev/stderr
+stderr_logfile_maxbytes=0


### PR DESCRIPTION
## Summary

- Adds a Docker-based token tool that simplifies obtaining the `logindata.json` file
- Users only need Docker installed - no Python, Firefox, or other dependencies required
- Supports auto-filling credentials so users only need to solve the CAPTCHA
- Includes a web server for easy token file download

## Changes

- New `token-tool/` directory with Docker setup
- Updated README with Docker tool as the recommended option (Python script kept as alternative)

## Usage

```bash
cd token-tool
# Edit docker-compose.yml with your credentials
docker compose up --build
# Open http://localhost:6080/vnc.html?autoconnect=true
# Wait for auto-fill, solve CAPTCHA
# Download from http://localhost:8000/logindata.json
```