### PR TITLE
Security: update pip to fix vulnerabilities

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
 colorlog==6.7.0
 homeassistant==2024.1.6
-pip>=21.0,<23.2
+pip>=25.3
 ruff==0.0.292


### PR DESCRIPTION
## Summary

Updates pip version constraint to fix two security vulnerabilities:

- **CVE-2023-5752** (Medium): Command Injection when used with Mercurial
- **CVE-2025-8869** (Medium): Symlink tar extraction vulnerability

## Changes

- `pip>=21.0,<23.2` → `pip>=25.3`

## Note

The homeassistant vulnerability (CVE-2025-65713) is left for a separate PR as it requires updating to ≥2025.8.0 which may have breaking changes.