### PR TITLE
Fix logindata.json path for Docker/read-only environments

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -158,3 +158,7 @@ config/**
 /utils/logindata.json
 venv
 .claude
+
+# Test config (may contain tokens)
+test_config/**
+!test_config/configuration.yaml

--- a/custom_components/carelink/__init__.py
+++ b/custom_components/carelink/__init__.py
@@ -128,7 +128,8 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
         config["cl_client_secret"],
         config["cl_mag_identifier"],
         config["patientId"],
-        config_path=hass.config.path()
+        config_path=hass.config.path(),
+        entry_id=entry.entry_id
     )
 
     hass.data.setdefault(DOMAIN, {})[entry.entry_id] = {CLIENT: carelink_client}

--- a/custom_components/carelink/__init__.py
+++ b/custom_components/carelink/__init__.py
@@ -127,7 +127,8 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
         config["cl_client_id"],
         config["cl_client_secret"],
         config["cl_mag_identifier"],
-        config["patientId"]
+        config["patientId"],
+        config_path=hass.config.path()
     )
 
     hass.data.setdefault(DOMAIN, {})[entry.entry_id] = {CLIENT: carelink_client}

--- a/custom_components/carelink/__init__.py
+++ b/custom_components/carelink/__init__.py
@@ -2,7 +2,9 @@
 from __future__ import annotations
 
 import logging
+import os
 import re
+import shutil
 
 from datetime import datetime, timedelta
 from zoneinfo import ZoneInfo
@@ -86,6 +88,9 @@ PLATFORMS: list[Platform] = [Platform.SENSOR, Platform.BINARY_SENSOR]
 
 _LOGGER = logging.getLogger(__name__)
 
+# Old logindata.json location (before fix for read-only filesystems)
+LEGACY_AUTH_FILE = "custom_components/carelink/logindata.json"
+
 # Fields containing personally identifiable information that should be redacted from logs
 PII_FIELDS = {
     "firstName", "lastName", "username", "patientId", "conduitSerialNumber",
@@ -114,10 +119,46 @@ def convert_date_to_isodate(date):
     return datetime.fromisoformat(date_iso).replace(tzinfo=None)
 
 
+def _migrate_legacy_logindata(config_path: str, entry_id: str) -> None:
+    """Migrate logindata.json from old location to new entry-specific location.
+
+    Old location: custom_components/carelink/logindata.json (relative to config)
+    New location: {config_path}/carelink_logindata_{entry_id}.json
+    """
+    from .api import AUTH_FILE_PREFIX
+
+    old_path = os.path.join(config_path, LEGACY_AUTH_FILE)
+    new_filename = f"{AUTH_FILE_PREFIX}_{entry_id}.json"
+    new_path = os.path.join(config_path, new_filename)
+
+    # Only migrate if old file exists and new file doesn't
+    if os.path.exists(old_path) and not os.path.exists(new_path):
+        try:
+            shutil.copy2(old_path, new_path)
+            _LOGGER.info(
+                "Migrated logindata from %s to %s",
+                old_path,
+                new_path
+            )
+            # Remove old file after successful migration
+            os.remove(old_path)
+            _LOGGER.debug("Removed legacy logindata file: %s", old_path)
+        except OSError as error:
+            _LOGGER.warning(
+                "Failed to migrate logindata from %s to %s: %s",
+                old_path,
+                new_path,
+                error
+            )
+
+
 async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     """Set up carelink from a config entry."""
 
     hass.data.setdefault(DOMAIN, {})
+
+    # Migrate logindata from old location if needed
+    _migrate_legacy_logindata(hass.config.path(), entry.entry_id)
 
     config = entry.data
 

--- a/custom_components/carelink/api.py
+++ b/custom_components/carelink/api.py
@@ -32,7 +32,7 @@ VERSION = "0.4"
 
 # Constants
 AUTH_EXPIRE_DEADLINE_MINUTES = 10
-CON_CONTEXT_AUTH = "custom_components/carelink/logindata.json"
+DEFAULT_AUTH_FILE = "carelink_logindata.json"
 CARELINK_CONFIG_URL = "https://clcloud.minimed.eu/connect/carepartner/v13/discover/android/3.6"
 AUTH_ERROR_CODES = [401,403]
 
@@ -58,7 +58,8 @@ class CarelinkClient:
         client_id,
         client_secret,
         mag_identifier,
-        carelink_patient_id
+        carelink_patient_id,
+        config_path=None
     ):
 
         # Auth info
@@ -74,6 +75,12 @@ class CarelinkClient:
 
         # Session info
         self.__carelink_patient_id = carelink_patient_id
+
+        # Config path for storing auth file
+        if config_path:
+            self.__auth_file_path = os.path.join(config_path, DEFAULT_AUTH_FILE)
+        else:
+            self.__auth_file_path = DEFAULT_AUTH_FILE
         self.__session_user = None
         self.__session_username = None
         self.__session_config = None
@@ -303,7 +310,7 @@ class CarelinkClient:
     async def __execute_init_procedure(self):
         printdbg("__execute_init_procedure()")
         if not self.__initialized:
-            self.__token_data = await self._process_token_file(CON_CONTEXT_AUTH)
+            self.__token_data = await self._process_token_file(self.__auth_file_path)
 
             if self.__token_data is None:
                 return
@@ -334,7 +341,7 @@ class CarelinkClient:
                         if await self.__refresh_token(self.__session_config, self.__token_data):
                             if await self._get_access_token_payload(self.__token_data):
                                 printdbg(f"New token is valid until {self.__auth_token_validto}")
-                                await self._write_token_file(self.__token_data, CON_CONTEXT_AUTH)
+                                await self._write_token_file(self.__token_data, self.__auth_file_path)
                     except Exception as e:
                         printdbg(e)
                     return
@@ -395,7 +402,7 @@ class CarelinkClient:
             if await self.__refresh_token(self.__session_config, self.__token_data):
                 if await self._get_access_token_payload(self.__token_data):
                     printdbg(f"New token is valid until {self.__auth_token_validto}")
-                    await self._write_token_file(self.__token_data, CON_CONTEXT_AUTH)
+                    await self._write_token_file(self.__token_data, self.__auth_file_path)
         return True
 
     # Wrapper for data retrival methods

--- a/custom_components/carelink/api.py
+++ b/custom_components/carelink/api.py
@@ -32,7 +32,7 @@ VERSION = "0.4"
 
 # Constants
 AUTH_EXPIRE_DEADLINE_MINUTES = 10
-DEFAULT_AUTH_FILE = "carelink_logindata.json"
+AUTH_FILE_PREFIX = "carelink_logindata"
 CARELINK_CONFIG_URL = "https://clcloud.minimed.eu/connect/carepartner/v13/discover/android/3.6"
 AUTH_ERROR_CODES = [401,403]
 
@@ -59,7 +59,8 @@ class CarelinkClient:
         client_secret,
         mag_identifier,
         carelink_patient_id,
-        config_path=None
+        config_path=None,
+        entry_id=None
     ):
 
         # Auth info
@@ -76,11 +77,16 @@ class CarelinkClient:
         # Session info
         self.__carelink_patient_id = carelink_patient_id
 
-        # Config path for storing auth file
-        if config_path:
-            self.__auth_file_path = os.path.join(config_path, DEFAULT_AUTH_FILE)
+        # Config path for storing auth file (unique per entry_id to support multiple instances)
+        if entry_id:
+            auth_filename = f"{AUTH_FILE_PREFIX}_{entry_id}.json"
         else:
-            self.__auth_file_path = DEFAULT_AUTH_FILE
+            auth_filename = f"{AUTH_FILE_PREFIX}.json"
+
+        if config_path:
+            self.__auth_file_path = os.path.join(config_path, auth_filename)
+        else:
+            self.__auth_file_path = auth_filename
         self.__session_user = None
         self.__session_username = None
         self.__session_config = None

--- a/custom_components/carelink/config_flow.py
+++ b/custom_components/carelink/config_flow.py
@@ -30,7 +30,8 @@ async def validate_input(hass: HomeAssistant, data: dict[str, Any]) -> dict[str,
         data.setdefault("cl_client_id", None),
         data.setdefault("cl_client_secret", None),
         data.setdefault("cl_mag_identifier", None),
-        data.setdefault("patientId", None)
+        data.setdefault("patientId", None),
+        config_path=hass.config.path()
     )
 
     try:

--- a/docker-compose.test.yml
+++ b/docker-compose.test.yml
@@ -1,0 +1,51 @@
+version: '3.8'
+
+# Local testing environment for Home Assistant Carelink integration
+# Usage:
+#   docker-compose -f docker-compose.test.yml up -d
+#   Open http://localhost:8123 to access Home Assistant
+#   docker-compose -f docker-compose.test.yml down -v  (to cleanup)
+
+services:
+  homeassistant:
+    image: ghcr.io/home-assistant/home-assistant:stable
+    container_name: carelink-ha-test
+    volumes:
+      # Mount the custom component
+      - ./custom_components/carelink:/config/custom_components/carelink:ro
+      # Mount test config directory (created on first run)
+      - ./test_config:/config
+    ports:
+      - "8123:8123"
+    environment:
+      - TZ=Europe/Amsterdam
+    restart: unless-stopped
+
+  # Optional: Local Nightscout instance for testing the uploader
+  # Uncomment the sections below to enable
+  #
+  # nightscout:
+  #   image: nightscout/cgm-remote-monitor:latest
+  #   container_name: carelink-nightscout-test
+  #   ports:
+  #     - "1337:1337"
+  #   environment:
+  #     - NODE_ENV=production
+  #     - TZ=Europe/Amsterdam
+  #     - MONGO_CONNECTION=mongodb://mongo:27017/nightscout
+  #     - API_SECRET=testingapisecret123
+  #     - DISPLAY_UNITS=mmol
+  #     - ENABLE=careportal rawbg iob cob openaps pump bwg cage sage iage bage basal ar2 errorcodes
+  #   depends_on:
+  #     - mongo
+  #   restart: unless-stopped
+  #
+  # mongo:
+  #   image: mongo:4.4
+  #   container_name: carelink-mongo-test
+  #   volumes:
+  #     - mongo_data:/data/db
+  #   restart: unless-stopped
+
+# volumes:
+#   mongo_data:

--- a/test_config/configuration.yaml
+++ b/test_config/configuration.yaml
@@ -1,0 +1,24 @@
+# Home Assistant Test Configuration for Carelink Integration
+# This file is used for local testing only
+
+homeassistant:
+  name: Carelink Test
+  unit_system: metric
+  time_zone: Europe/Amsterdam
+  currency: EUR
+
+# Enable logging for debugging
+logger:
+  default: info
+  logs:
+    custom_components.carelink: debug
+
+# Enable the frontend
+frontend:
+
+# Enable configuration UI
+config:
+
+# Uncomment to enable Lovelace in YAML mode
+# lovelace:
+#   mode: yaml

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -161,7 +161,7 @@ def mock_recent_data() -> dict[str, Any]:
 
 
 @pytest.fixture
-def mock_carelink_client(mock_token_data: dict[str, str]) -> CarelinkClient:
+def mock_carelink_client(mock_token_data: dict[str, str], tmp_path) -> CarelinkClient:
     """Return a CarelinkClient instance for testing."""
     client = CarelinkClient(
         carelink_refresh_token=mock_token_data["refresh_token"],
@@ -170,6 +170,7 @@ def mock_carelink_client(mock_token_data: dict[str, str]) -> CarelinkClient:
         client_secret=mock_token_data["client_secret"],
         mag_identifier=mock_token_data["mag-identifier"],
         carelink_patient_id="mock_patient_id",
+        config_path=str(tmp_path),
     )
     return client
 

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -423,3 +423,74 @@ class TestGetLastMarker:
 
         # Should return the 18:00 marker (most recent)
         assert result["ATTRS"]["amount"] == 60
+
+
+class TestMigrateLegacyLogindata:
+    """Tests for the _migrate_legacy_logindata function."""
+
+    def test_migrate_legacy_file_exists(self, tmp_path):
+        """Test migration when legacy file exists and new file doesn't."""
+        from custom_components.carelink import _migrate_legacy_logindata, LEGACY_AUTH_FILE
+        from custom_components.carelink.api import AUTH_FILE_PREFIX
+
+        # Create the legacy directory structure
+        legacy_dir = tmp_path / "custom_components" / "carelink"
+        legacy_dir.mkdir(parents=True)
+        legacy_file = legacy_dir / "logindata.json"
+        legacy_file.write_text('{"access_token": "test123"}')
+
+        entry_id = "test_entry_123"
+        new_filename = f"{AUTH_FILE_PREFIX}_{entry_id}.json"
+
+        # Run migration
+        _migrate_legacy_logindata(str(tmp_path), entry_id)
+
+        # Check new file exists with correct content
+        new_file = tmp_path / new_filename
+        assert new_file.exists()
+        assert new_file.read_text() == '{"access_token": "test123"}'
+
+        # Check legacy file is removed
+        assert not legacy_file.exists()
+
+    def test_migrate_no_legacy_file(self, tmp_path):
+        """Test migration does nothing when legacy file doesn't exist."""
+        from custom_components.carelink import _migrate_legacy_logindata
+        from custom_components.carelink.api import AUTH_FILE_PREFIX
+
+        entry_id = "test_entry_456"
+        new_filename = f"{AUTH_FILE_PREFIX}_{entry_id}.json"
+
+        # Run migration (no legacy file exists)
+        _migrate_legacy_logindata(str(tmp_path), entry_id)
+
+        # Check no new file was created
+        new_file = tmp_path / new_filename
+        assert not new_file.exists()
+
+    def test_migrate_new_file_already_exists(self, tmp_path):
+        """Test migration skips if new file already exists."""
+        from custom_components.carelink import _migrate_legacy_logindata, LEGACY_AUTH_FILE
+        from custom_components.carelink.api import AUTH_FILE_PREFIX
+
+        # Create the legacy directory structure and file
+        legacy_dir = tmp_path / "custom_components" / "carelink"
+        legacy_dir.mkdir(parents=True)
+        legacy_file = legacy_dir / "logindata.json"
+        legacy_file.write_text('{"access_token": "old_token"}')
+
+        entry_id = "test_entry_789"
+        new_filename = f"{AUTH_FILE_PREFIX}_{entry_id}.json"
+
+        # Create the new file already
+        new_file = tmp_path / new_filename
+        new_file.write_text('{"access_token": "new_token"}')
+
+        # Run migration
+        _migrate_legacy_logindata(str(tmp_path), entry_id)
+
+        # Check new file wasn't overwritten
+        assert new_file.read_text() == '{"access_token": "new_token"}'
+
+        # Check legacy file still exists (not removed since migration was skipped)
+        assert legacy_file.exists()


### PR DESCRIPTION
## Summary

- Fix bug where `logindata.json` was written to read-only custom_components directory
- Add `config_path` parameter to `CarelinkClient` to specify where to store auth file
- Store `carelink_logindata_{entry_id}.json` in Home Assistant config directory
- Support multiple integration instances with unique files per entry_id
- **Migrate existing logindata.json** from old location to new location automatically

## Changes

| File | Change |
|------|--------|
| `api.py` | Add `config_path` and `entry_id` parameters, use unique `AUTH_FILE_PREFIX` |
| `__init__.py` | Pass `hass.config.path()` and `entry.entry_id`, add migration logic |
| `config_flow.py` | Pass `hass.config.path()` to CarelinkClient |
| `conftest.py` | Update tests to use `tmp_path` for config |

## Migration

Existing users will have their `logindata.json` automatically migrated:
- **From:** `custom_components/carelink/logindata.json`
- **To:** `{config}/carelink_logindata_{entry_id}.json`

This prevents users from having to re-authenticate when upgrading.

## Testing

- Add `docker-compose.test.yml` for local testing
- Add `test_config/configuration.yaml` with debug logging
