### PR TITLE
Fix ValueError for string faultId values (Simplera sensor support)

### DIFF
--- a/custom_components/carelink/__init__.py
+++ b/custom_components/carelink/__init__.py
@@ -355,7 +355,16 @@ class CarelinkCoordinator(DataUpdateCoordinator):
             date_time_local = convert_date_to_isodate(last_alarm["dateTime"])
 
             last_alarm["dateTime"]=date_time_local
-            last_alarm["messageId"] = CARELINK_CODE_MAP.setdefault(int(last_alarm["faultId"]), "UNKNOWN")
+            # Handle both numeric and string faultId values (Simplera sensor uses strings like 'alert.sg.threshold.low')
+            fault_id = last_alarm.get("faultId")
+            if fault_id is not None:
+                try:
+                    last_alarm["messageId"] = CARELINK_CODE_MAP.get(int(fault_id), "UNKNOWN")
+                except (ValueError, TypeError):
+                    # String faultId (e.g. 'alert.sg.threshold.low') - use as-is since it's already descriptive
+                    last_alarm["messageId"] = str(fault_id)
+            else:
+                last_alarm["messageId"] = "UNKNOWN"
             
             data[SENSOR_KEY_LAST_ALARM] = date_time_local.replace(tzinfo=timezone)
             data[SENSOR_KEY_LAST_ALARM_ATTRS] = last_alarm

--- a/custom_components/carelink/nightscout_uploader.py
+++ b/custom_components/carelink/nightscout_uploader.py
@@ -259,6 +259,13 @@ class NightscoutUploader:
         result = list()
         for msg in raw:
             date, date_string=self.__getDataStringFromIso(msg["dateTime"], tz)
+            # Handle both numeric and string faultId values (Simplera sensor uses strings)
+            fault_id = msg.get('faultId')
+            try:
+                message_id = CARELINK_CODE_MAP.get(int(fault_id), "Unknown") if fault_id is not None else "Unknown"
+            except (ValueError, TypeError):
+                message_id = str(fault_id) if fault_id else "Unknown"
+
             if "additionalInfo" in msg and "sg" in msg["additionalInfo"] and int(msg["additionalInfo"]["sg"]) < 400:
                 result.append(dict(
                     timestamp=date,
@@ -267,7 +274,7 @@ class NightscoutUploader:
                     eventType="Note",
                     glucoseType="sensor",
                     glucose=float(msg["additionalInfo"]["sg"]),
-                    notes=self.__getNote(CARELINK_CODE_MAP.setdefault(int(msg['faultId']), "Unknown"))
+                    notes=self.__getNote(message_id)
                     ))
             else:
                 result.append(dict(
@@ -275,7 +282,7 @@ class NightscoutUploader:
                     enteredBy=NS_USER_AGENT,
                     created_at=date_string,
                     eventType="Note",
-                    notes=self.__getNote(CARELINK_CODE_MAP.setdefault(int(msg['faultId']), "Unknown"))
+                    notes=self.__getNote(message_id)
                     ))
         return result
 


### PR DESCRIPTION
## Summary

Fixes a crash for users with Simplera sensor (without pump) where `faultId` is a string instead of a number.

## Bug

```
ValueError: invalid literal for int() with base 10: 'alert.sg.threshold.low'
```

The code assumed `faultId` was always numeric, but Simplera sensors return descriptive strings like `'alert.sg.threshold.low'`.

## Fix

- Handle both numeric and string `faultId` values
- Use `.get()` instead of `.setdefault()` (don't modify `CARELINK_CODE_MAP`)
- For string faultIds, use the value as-is (already descriptive)

## Changes

| File | Change |
|------|--------|
| `__init__.py` | Handle string faultId in last_alarm processing |
| `nightscout_uploader.py` | Handle string faultId in __getMsgEntries |
