### PR TITLE
Add Carelink Token Generator Home Assistant add-on

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,11 +31,30 @@ Copy the `custom_components/carelink` to your `custom_components` folder. Reboot
 ### Carelink Login Data
 The needed information for the authentification process can either be provided as file (=logindata.json), or entered during the initial setup of the integration.
 #### Get the data
-The Home Assistant Carelink Integration needs the initial login data stored in the `logindata.json` file. There are two ways to create this file:
+The Home Assistant Carelink Integration needs the initial login data stored in the `logindata.json` file. There are three ways to create this file:
 
-##### Option 1: Docker Token Tool (Recommended)
+##### Option 1: Home Assistant Add-on (Recommended)
 
-The easiest way to get your `logindata.json` is using our Docker-based token tool. This requires only Docker - no Python or other dependencies needed.
+The easiest way to get your `logindata.json` is using the Carelink Token Generator add-on directly in Home Assistant. No technical knowledge required.
+
+1. Add this repository to your Home Assistant add-on store:
+   ```
+   https://github.com/yo-han/Home-Assistant-Carelink
+   ```
+
+2. Install the "Carelink Token Generator" add-on
+
+3. Configure your region (EU or US) and start the add-on
+
+4. Click "Open Web UI" and follow the login process
+
+5. The token file will be saved automatically - you can then add the Carelink integration with empty fields
+
+For more details, see the [Add-on README](carelink-token-generator/README.md).
+
+##### Option 2: Docker Token Tool
+
+If you can't use the Home Assistant add-on, you can use our Docker-based token tool. This requires Docker to be installed on your computer.
 
 1. Navigate to the token-tool folder and set up your credentials:
    ```bash
@@ -57,7 +76,7 @@ The easiest way to get your `logindata.json` is using our Docker-based token too
 
 For more details and troubleshooting, see the [Token Tool README](token-tool/README.md).
 
-##### Option 2: Python Script
+##### Option 3: Python Script
 
 Alternatively, you can run the login script directly on a PC with a screen.
 The login script from [@ondrej1024](https://github.com/ondrej1024)'s Carelink Python API, written by @palmarci (Pal Marci), was slightly modified and can be found here ["carelink_carepartner_api_login.py"](https://github.com/yo-han/Home-Assistant-Carelink/blob/develop/utils/carelink_carepartner_api_login.py).

--- a/carelink-token-generator/CHANGELOG.md
+++ b/carelink-token-generator/CHANGELOG.md
@@ -1,0 +1,9 @@
+# Changelog
+
+## 1.0.0 - 2026-01-12
+
+### Added
+- Initial release
+- Web UI for generating Carelink login tokens
+- Support for EU and US regions
+- Automatic token file placement in Home Assistant config

--- a/carelink-token-generator/Dockerfile
+++ b/carelink-token-generator/Dockerfile
@@ -1,0 +1,53 @@
+ARG BUILD_FROM
+FROM ${BUILD_FROM}
+
+# Install system dependencies
+RUN apk add --no-cache \
+    python3 \
+    py3-pip \
+    firefox \
+    xvfb \
+    dbus \
+    ttf-freefont \
+    font-noto \
+    curl \
+    && rm -rf /var/cache/apk/*
+
+# Install geckodriver
+ARG GECKODRIVER_VERSION=v0.35.0
+RUN ARCH=$(uname -m) && \
+    if [ "$ARCH" = "x86_64" ]; then GECKO_ARCH="linux64"; \
+    elif [ "$ARCH" = "aarch64" ]; then GECKO_ARCH="linux-aarch64"; \
+    else echo "Unsupported architecture: $ARCH" && exit 1; fi && \
+    curl -sL "https://github.com/mozilla/geckodriver/releases/download/${GECKODRIVER_VERSION}/geckodriver-${GECKODRIVER_VERSION}-${GECKO_ARCH}.tar.gz" \
+    -o /tmp/geckodriver.tar.gz && \
+    tar -xzf /tmp/geckodriver.tar.gz -C /usr/local/bin/ && \
+    rm /tmp/geckodriver.tar.gz && \
+    chmod +x /usr/local/bin/geckodriver
+
+# Create virtual environment and install Python dependencies
+RUN python3 -m venv /opt/venv
+ENV PATH="/opt/venv/bin:$PATH"
+
+RUN pip install --no-cache-dir \
+    flask==3.0.0 \
+    requests==2.31.0 \
+    pyOpenSSL==24.0.0 \
+    selenium-wire==5.1.0 \
+    curlify==2.2.1 \
+    blinker==1.7.0
+
+# Copy application files
+COPY rootfs /
+
+# Set working directory
+WORKDIR /app
+
+# Set display for headless Firefox
+ENV DISPLAY=:99
+
+# Expose ingress port
+EXPOSE 8099
+
+# Run script
+CMD ["/run.sh"]

--- a/carelink-token-generator/README.md
+++ b/carelink-token-generator/README.md
@@ -1,0 +1,80 @@
+# Carelink Token Generator
+
+A Home Assistant add-on that provides a web interface for generating Carelink login tokens.
+
+## About
+
+This add-on makes it easy for non-technical users to generate the `logindata.json` file required by the [Carelink Integration](https://github.com/yo-han/Home-Assistant-Carelink). No Python or Docker knowledge required.
+
+## Features
+
+- Simple web-based interface accessible from the Home Assistant sidebar
+- Support for both EU and US Carelink regions
+- Automatic token file placement in your Home Assistant config directory
+- Secure OAuth authentication flow using headless Firefox
+
+## Installation
+
+1. Add this repository to your Home Assistant add-on store:
+   ```
+   https://github.com/yo-han/Home-Assistant-Carelink
+   ```
+
+2. Find "Carelink Token Generator" in the add-on store and click **Install**
+
+3. Configure your region (EU or US) in the add-on configuration
+
+4. Start the add-on
+
+5. Click **Open Web UI** or find "Carelink Tokens" in your sidebar
+
+## Usage
+
+1. Open the add-on web interface
+2. Click **Start Login Process**
+3. A browser window will handle the Carelink OAuth flow
+4. Log in with your Carelink credentials when prompted
+5. Complete any CAPTCHA verification if required
+6. The token will be saved automatically to your Home Assistant config directory
+
+After generating the token:
+
+1. Go to **Settings** → **Devices & Services** → **Add Integration**
+2. Search for "Carelink"
+3. Leave the username and password fields empty
+4. The integration will automatically use the generated token file
+
+## Configuration
+
+| Option | Description |
+|--------|-------------|
+| `region` | Your Carelink region: `eu` (Europe) or `us` (United States) |
+
+## Troubleshooting
+
+### Login times out
+
+The login process has a 5-minute timeout. If you encounter a timeout:
+- Make sure you complete the login within 5 minutes
+- Check that your Carelink credentials are correct
+- Try again with the "Start Over" button
+
+### Token file not found
+
+If the Carelink integration can't find the token file:
+- Ensure the add-on completed successfully (green checkmark)
+- Check that the file exists at `/config/carelink_logindata.json`
+- Restart Home Assistant and try adding the integration again
+
+## Technical Details
+
+This add-on runs:
+- Flask web server on port 8099 (accessed via Home Assistant ingress)
+- Xvfb virtual display for headless browser operation
+- Firefox with Selenium for OAuth flow automation
+
+The generated token file is saved to `/config/carelink_logindata.json` which is the Home Assistant config directory.
+
+## Support
+
+For issues and feature requests, please use the [GitHub issue tracker](https://github.com/yo-han/Home-Assistant-Carelink/issues).

--- a/carelink-token-generator/build.yaml
+++ b/carelink-token-generator/build.yaml
@@ -1,0 +1,3 @@
+build_from:
+  amd64: ghcr.io/home-assistant/amd64-base:3.19
+  aarch64: ghcr.io/home-assistant/aarch64-base:3.19

--- a/carelink-token-generator/config.yaml
+++ b/carelink-token-generator/config.yaml
@@ -1,0 +1,42 @@
+name: Carelink Token Generator
+version: 1.0.0
+slug: carelink-token-generator
+description: Generate Carelink login tokens for the Carelink integration
+url: https://github.com/yo-han/Home-Assistant-Carelink
+
+# Supported architectures
+arch:
+  - amd64
+  - aarch64
+
+# Startup priority
+startup: application
+boot: manual
+
+# Configuration options shown in UI
+options:
+  region: eu
+
+schema:
+  region: list(eu|us)
+
+# Enable web UI via ingress
+ingress: true
+ingress_port: 8099
+
+# Panel in sidebar
+panel_title: Carelink Tokens
+panel_icon: mdi:key-variant
+
+# Mount Home Assistant config to save logindata.json
+map:
+  - homeassistant_config:rw
+
+# Required for running Firefox/Selenium
+privileged: true
+
+# Host network for browser
+host_network: false
+
+# Init system
+init: false

--- a/carelink-token-generator/rootfs/app/carelink_auth.py
+++ b/carelink-token-generator/rootfs/app/carelink_auth.py
@@ -1,0 +1,319 @@
+"""Carelink Authentication Module for Home Assistant Add-on."""
+import base64
+import hashlib
+import json
+import logging
+import os
+import random
+import re
+import secrets
+import string
+import uuid
+from time import sleep
+
+import requests
+import OpenSSL
+from seleniumwire import webdriver
+from selenium.webdriver.firefox.options import Options
+from selenium.webdriver.firefox.service import Service
+
+logger = logging.getLogger(__name__)
+
+# Configuration
+DISCOVERY_URL = "https://clcloud.minimed.eu/connect/carepartner/v13/discover/android/3.6"
+RSA_KEYSIZE = 2048
+
+
+class CarelinkAuth:
+    """Handle Carelink authentication flow."""
+
+    def __init__(self, region: str = "eu", output_file: str = "logindata.json"):
+        """Initialize the auth handler."""
+        self.region = region.lower()
+        self.output_file = output_file
+        self.is_us_region = self.region == "us"
+
+    def login(self) -> bool:
+        """Perform the login process and save tokens."""
+        try:
+            logger.info(f"Starting login for region: {self.region}")
+            endpoint_config = self._resolve_endpoint_config()
+
+            sso_config, api_base_url, is_auth0 = endpoint_config
+
+            if is_auth0:
+                token_data = self._do_login_auth0(endpoint_config)
+            else:
+                token_data = self._do_login_non_auth0(endpoint_config)
+
+            if token_data:
+                self._write_datafile(token_data)
+                logger.info(f"Token saved to {self.output_file}")
+                return True
+
+            return False
+
+        except Exception as e:
+            logger.exception(f"Login failed: {e}")
+            raise
+
+    def _resolve_endpoint_config(self):
+        """Resolve the API endpoint configuration."""
+        discover_resp = requests.get(DISCOVERY_URL).json()
+        sso_url = None
+        is_auth0 = False
+
+        for c in discover_resp["CP"]:
+            if c["region"].lower() == "us" and self.is_us_region:
+                key = c["UseSSOConfiguration"]
+                sso_url = c[key]
+                is_auth0 = "Auth0" in key
+            elif c["region"].lower() == "eu" and not self.is_us_region:
+                key = c["UseSSOConfiguration"]
+                sso_url = c[key]
+                is_auth0 = "Auth0" in key
+
+        if sso_url is None:
+            raise Exception("Could not get SSO config url")
+
+        sso_config = requests.get(sso_url).json()
+
+        if is_auth0:
+            api_base_url = sso_config.get("issuer", "").rstrip("/")
+        else:
+            api_base_url = f"https://{sso_config['server']['hostname']}:{sso_config['server']['port']}/{sso_config['server']['prefix']}"
+            if api_base_url.endswith("/"):
+                api_base_url = api_base_url[:-1]
+
+        return sso_config, api_base_url, is_auth0
+
+    def _create_browser(self):
+        """Create a Firefox browser instance."""
+        options = Options()
+
+        # Run in headless mode for the add-on
+        # Users won't see the browser, but Selenium will handle the flow
+        options.add_argument("--headless")
+        options.add_argument("--no-sandbox")
+        options.add_argument("--disable-dev-shm-usage")
+
+        # Set preferences
+        options.set_preference("browser.download.folderList", 2)
+        options.set_preference("browser.helperApps.alwaysAsk.force", False)
+
+        service = Service(executable_path="/usr/local/bin/geckodriver")
+
+        driver = webdriver.Firefox(options=options, service=service)
+        return driver
+
+    def _do_captcha(self, url: str, redirect_url: str):
+        """Handle the OAuth login flow via browser."""
+        logger.info("Opening browser for login...")
+        driver = self._create_browser()
+
+        try:
+            driver.get(url)
+            logger.info(f"Navigated to login page")
+
+            # Wait for the redirect with the auth code
+            max_wait = 300  # 5 minutes timeout
+            waited = 0
+
+            while waited < max_wait:
+                for request in driver.requests:
+                    if request.response:
+                        if request.response.status_code == 302:
+                            if "location" in request.response.headers:
+                                location = request.response.headers["location"]
+                                if redirect_url in location:
+                                    code_match = re.search(r"code=([^&]+)", location)
+                                    if code_match:
+                                        code = code_match.group(1)
+                                        state = None
+                                        state_match = re.search(r"state=([^&]+)", location)
+                                        if state_match:
+                                            state = state_match.group(1)
+                                        logger.info("Got authorization code")
+                                        return (code, state)
+                sleep(0.5)
+                waited += 0.5
+
+            raise Exception("Login timeout - no authorization code received")
+
+        finally:
+            driver.quit()
+
+    def _do_login_auth0(self, endpoint_config):
+        """Perform Auth0 login flow."""
+        sso_config, api_base_url, _ = endpoint_config
+
+        auth_params = {
+            "client_id": sso_config["client"]["client_id"],
+            "response_type": "code",
+            "scope": sso_config["client"]["scope"],
+            "redirect_uri": sso_config["client"]["redirect_uri"],
+            "audience": sso_config["client"]["audience"],
+        }
+
+        authorize_url = api_base_url + sso_config["system_endpoints"]["authorization_endpoint_path"]
+        captcha_url = f"{authorize_url}?{'&'.join(f'{key}={value}' for key, value in auth_params.items())}"
+
+        captcha_code, _ = self._do_captcha(captcha_url, sso_config["client"]["redirect_uri"])
+
+        token_req_url = api_base_url + sso_config["system_endpoints"]["token_endpoint_path"]
+        token_req_data = {
+            "grant_type": "authorization_code",
+            "client_id": sso_config["client"]["client_id"],
+            "code": captcha_code,
+            "redirect_uri": sso_config["client"]["redirect_uri"],
+        }
+
+        token_resp = requests.post(token_req_url, data=token_req_data)
+        if token_resp.status_code != 200:
+            raise Exception(f"Could not get token: {token_resp.text}")
+
+        token_data = token_resp.json()
+        token_data["client_id"] = token_req_data["client_id"]
+
+        # Remove unnecessary fields
+        token_data.pop("expires_in", None)
+        token_data.pop("token_type", None)
+
+        return token_data
+
+    def _do_login_non_auth0(self, endpoint_config):
+        """Perform non-Auth0 (MAG) login flow."""
+        sso_config, api_base_url, _ = endpoint_config
+
+        # Step 1: Initialize client
+        data = {
+            "client_id": sso_config["oauth"]["client"]["client_ids"][0]["client_id"],
+            "nonce": str(uuid.UUID(bytes=secrets.token_bytes(16))),
+        }
+        headers = {
+            "device-id": base64.b64encode(hashlib.sha256(os.urandom(40)).hexdigest().encode()).decode()
+        }
+
+        client_init_url = api_base_url + sso_config["mag"]["system_endpoints"]["client_credential_init_endpoint_path"]
+        client_init_resp = requests.post(client_init_url, data=data, headers=headers).json()
+
+        # Step 2: Prepare authorization
+        client_code_verifier = base64.urlsafe_b64encode(os.urandom(40)).decode("utf-8")
+        client_code_verifier = re.sub("[^a-zA-Z0-9]+", "", client_code_verifier)
+        client_code_challenge = hashlib.sha256(client_code_verifier.encode("utf-8")).digest()
+        client_code_challenge = base64.urlsafe_b64encode(client_code_challenge).decode("utf-8").replace("=", "")
+
+        client_state = self._random_b64_str(22)
+        auth_params = {
+            "client_id": client_init_resp["client_id"],
+            "response_type": "code",
+            "display": "social_login",
+            "scope": sso_config["oauth"]["client"]["client_ids"][0]["scope"],
+            "redirect_uri": sso_config["oauth"]["client"]["client_ids"][0]["redirect_uri"],
+            "code_challenge": client_code_challenge,
+            "code_challenge_method": "S256",
+            "state": client_state,
+        }
+
+        authorize_url = api_base_url + sso_config["oauth"]["system_endpoints"]["authorization_endpoint_path"]
+        providers = requests.get(authorize_url, params=auth_params).json()
+        captcha_url = providers["providers"][0]["provider"]["auth_url"]
+
+        # Step 3: OAuth login
+        captcha_code, _ = self._do_captcha(captcha_url, sso_config["oauth"]["client"]["client_ids"][0]["redirect_uri"])
+
+        # Step 4: Device registration
+        register_device_id = hashlib.sha256(os.urandom(40)).hexdigest()
+        client_auth_str = f"{client_init_resp['client_id']}:{client_init_resp['client_secret']}"
+
+        android_model = random.choice(["SM-G973F", "SM-G988U1", "SM-G981W", "SM-G9600"])
+        android_model_safe = re.sub(r"[^a-zA-Z0-9]", "", android_model)
+
+        keypair = OpenSSL.crypto.PKey()
+        keypair.generate_key(OpenSSL.crypto.TYPE_RSA, RSA_KEYSIZE)
+        csr = self._create_csr(keypair, "socialLogin", register_device_id, android_model_safe,
+                               sso_config["oauth"]["client"]["organization"])
+
+        reg_headers = {
+            "device-name": base64.b64encode(android_model.encode()).decode(),
+            "authorization": f"Bearer {captcha_code}",
+            "cert-format": "pem",
+            "client-authorization": "Basic " + base64.b64encode(client_auth_str.encode()).decode(),
+            "create-session": "true",
+            "code-verifier": client_code_verifier,
+            "device-id": base64.b64encode(register_device_id.encode()).decode(),
+            "redirect-uri": sso_config["oauth"]["client"]["client_ids"][0]["redirect_uri"],
+        }
+
+        csr = self._reformat_csr(csr)
+        reg_url = api_base_url + sso_config["mag"]["system_endpoints"]["device_register_endpoint_path"]
+        reg_resp = requests.post(reg_url, headers=reg_headers, data=csr)
+
+        if reg_resp.status_code != 200:
+            raise Exception(f"Could not register: {reg_resp.json().get('error_description', reg_resp.text)}")
+
+        # Step 5: Get token
+        token_req_url = api_base_url + sso_config["oauth"]["system_endpoints"]["token_endpoint_path"]
+        token_req_data = {
+            "assertion": reg_resp.headers["id-token"],
+            "client_id": client_init_resp["client_id"],
+            "client_secret": client_init_resp["client_secret"],
+            "scope": sso_config["oauth"]["client"]["client_ids"][0]["scope"],
+            "grant_type": reg_resp.headers["id-token-type"],
+        }
+
+        token_resp = requests.post(
+            token_req_url,
+            headers={"mag-identifier": reg_resp.headers["mag-identifier"]},
+            data=token_req_data
+        )
+
+        if token_resp.status_code != 200:
+            raise Exception("Could not get token data")
+
+        token_data = token_resp.json()
+        token_data["client_id"] = token_req_data["client_id"]
+        token_data["client_secret"] = token_req_data["client_secret"]
+        token_data["mag-identifier"] = reg_resp.headers["mag-identifier"]
+
+        # Remove unnecessary fields
+        token_data.pop("expires_in", None)
+        token_data.pop("token_type", None)
+
+        return token_data
+
+    def _create_csr(self, keypair, cn, ou, dc, o):
+        """Create a Certificate Signing Request."""
+        req = OpenSSL.crypto.X509Req()
+        req.get_subject().CN = cn
+        req.get_subject().OU = ou
+        req.get_subject().DC = dc
+        req.get_subject().O = o
+        req.set_pubkey(keypair)
+        req.sign(keypair, "sha256")
+        return OpenSSL.crypto.dump_certificate_request(OpenSSL.crypto.FILETYPE_PEM, req)
+
+    def _reformat_csr(self, csr):
+        """Reformat CSR for the API."""
+        csr = csr.decode()
+        csr = csr.replace("\n", "")
+        csr = csr.replace("-----BEGIN CERTIFICATE REQUEST-----", "")
+        csr = csr.replace("-----END CERTIFICATE REQUEST-----", "")
+        csr_raw = base64.b64decode(csr.encode())
+        return base64.urlsafe_b64encode(csr_raw).decode()
+
+    def _random_b64_str(self, length):
+        """Generate a random base64 string."""
+        random_chars = "".join(random.choice(string.ascii_letters + string.digits) for _ in range(length + 10))
+        base64_string = base64.b64encode(random_chars.encode("utf-8")).decode("utf-8")
+        return base64_string[:length]
+
+    def _write_datafile(self, obj):
+        """Write token data to file."""
+        # Ensure directory exists
+        os.makedirs(os.path.dirname(self.output_file), exist_ok=True)
+
+        with open(self.output_file, "w") as f:
+            json.dump(obj, f, indent=4)
+
+        logger.info(f"Wrote token data to {self.output_file}")

--- a/carelink-token-generator/rootfs/app/server.py
+++ b/carelink-token-generator/rootfs/app/server.py
@@ -98,7 +98,7 @@ def start_auth():
             logger.exception("Authentication error")
             auth_status = {
                 "status": "error",
-                "message": f"Error: {str(e)}",
+                "message": "An internal error occurred during authentication. Please try again.",
                 "token_file": None
             }
 

--- a/carelink-token-generator/rootfs/app/server.py
+++ b/carelink-token-generator/rootfs/app/server.py
@@ -1,0 +1,125 @@
+"""Carelink Token Generator - Web UI Server."""
+import json
+import logging
+import os
+import threading
+from flask import Flask, render_template, jsonify, request
+
+from carelink_auth import CarelinkAuth
+
+# Configure logging
+logging.basicConfig(level=logging.INFO)
+logger = logging.getLogger(__name__)
+
+app = Flask(__name__)
+
+# Global state
+auth_status = {
+    "status": "idle",  # idle, running, success, error
+    "message": "",
+    "token_file": None
+}
+auth_thread = None
+
+# Read region from options
+def get_region():
+    """Get region from add-on options."""
+    options_file = "/data/options.json"
+    if os.path.exists(options_file):
+        with open(options_file) as f:
+            options = json.load(f)
+            return options.get("region", "eu")
+    return "eu"
+
+# Output path for logindata.json
+def get_output_path():
+    """Get the output path for logindata.json."""
+    # Save to HA config directory
+    ha_config = "/homeassistant"
+    legacy_path = os.path.join(ha_config, "custom_components", "carelink")
+
+    # Create directory if it doesn't exist
+    os.makedirs(legacy_path, exist_ok=True)
+
+    return os.path.join(legacy_path, "logindata.json")
+
+
+@app.route("/")
+def index():
+    """Render the main page."""
+    region = get_region()
+    return render_template("index.html", region=region)
+
+
+@app.route("/status")
+def status():
+    """Get current authentication status."""
+    return jsonify(auth_status)
+
+
+@app.route("/start", methods=["POST"])
+def start_auth():
+    """Start the authentication process."""
+    global auth_thread, auth_status
+
+    if auth_status["status"] == "running":
+        return jsonify({"error": "Authentication already in progress"}), 400
+
+    auth_status = {
+        "status": "running",
+        "message": "Starting authentication...",
+        "token_file": None
+    }
+
+    region = get_region()
+    output_path = get_output_path()
+
+    def run_auth():
+        global auth_status
+        try:
+            auth = CarelinkAuth(region=region, output_file=output_path)
+            auth_status["message"] = "Opening browser for login..."
+
+            result = auth.login()
+
+            if result:
+                auth_status = {
+                    "status": "success",
+                    "message": f"Login successful! Token saved to {output_path}",
+                    "token_file": output_path
+                }
+            else:
+                auth_status = {
+                    "status": "error",
+                    "message": "Login failed. Please try again.",
+                    "token_file": None
+                }
+        except Exception as e:
+            logger.exception("Authentication error")
+            auth_status = {
+                "status": "error",
+                "message": f"Error: {str(e)}",
+                "token_file": None
+            }
+
+    auth_thread = threading.Thread(target=run_auth, daemon=True)
+    auth_thread.start()
+
+    return jsonify({"status": "started"})
+
+
+@app.route("/reset", methods=["POST"])
+def reset():
+    """Reset the authentication status."""
+    global auth_status
+    auth_status = {
+        "status": "idle",
+        "message": "",
+        "token_file": None
+    }
+    return jsonify({"status": "reset"})
+
+
+if __name__ == "__main__":
+    # Only allow connections from ingress
+    app.run(host="0.0.0.0", port=8099)

--- a/carelink-token-generator/rootfs/app/templates/index.html
+++ b/carelink-token-generator/rootfs/app/templates/index.html
@@ -1,0 +1,330 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Carelink Token Generator</title>
+    <style>
+        :root {
+            --primary-color: #03a9f4;
+            --success-color: #4caf50;
+            --error-color: #f44336;
+            --bg-color: #1c1c1c;
+            --card-bg: #2d2d2d;
+            --text-color: #ffffff;
+            --text-secondary: #b0b0b0;
+        }
+
+        * {
+            box-sizing: border-box;
+            margin: 0;
+            padding: 0;
+        }
+
+        body {
+            font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Oxygen, Ubuntu, sans-serif;
+            background-color: var(--bg-color);
+            color: var(--text-color);
+            min-height: 100vh;
+            display: flex;
+            justify-content: center;
+            align-items: center;
+            padding: 20px;
+        }
+
+        .container {
+            max-width: 500px;
+            width: 100%;
+        }
+
+        .card {
+            background-color: var(--card-bg);
+            border-radius: 12px;
+            padding: 32px;
+            box-shadow: 0 4px 6px rgba(0, 0, 0, 0.3);
+        }
+
+        .header {
+            text-align: center;
+            margin-bottom: 32px;
+        }
+
+        .header h1 {
+            font-size: 24px;
+            font-weight: 500;
+            margin-bottom: 8px;
+        }
+
+        .header p {
+            color: var(--text-secondary);
+            font-size: 14px;
+        }
+
+        .region-badge {
+            display: inline-block;
+            background-color: var(--primary-color);
+            color: white;
+            padding: 4px 12px;
+            border-radius: 16px;
+            font-size: 12px;
+            margin-top: 8px;
+        }
+
+        .status-container {
+            margin-bottom: 24px;
+            padding: 16px;
+            border-radius: 8px;
+            background-color: rgba(255, 255, 255, 0.05);
+        }
+
+        .status-idle {
+            border-left: 4px solid var(--text-secondary);
+        }
+
+        .status-running {
+            border-left: 4px solid var(--primary-color);
+        }
+
+        .status-success {
+            border-left: 4px solid var(--success-color);
+        }
+
+        .status-error {
+            border-left: 4px solid var(--error-color);
+        }
+
+        .status-label {
+            font-size: 12px;
+            text-transform: uppercase;
+            color: var(--text-secondary);
+            margin-bottom: 4px;
+        }
+
+        .status-message {
+            font-size: 14px;
+        }
+
+        .spinner {
+            display: inline-block;
+            width: 16px;
+            height: 16px;
+            border: 2px solid rgba(255, 255, 255, 0.3);
+            border-radius: 50%;
+            border-top-color: var(--primary-color);
+            animation: spin 1s linear infinite;
+            margin-right: 8px;
+            vertical-align: middle;
+        }
+
+        @keyframes spin {
+            to { transform: rotate(360deg); }
+        }
+
+        .btn {
+            width: 100%;
+            padding: 14px 24px;
+            font-size: 16px;
+            font-weight: 500;
+            border: none;
+            border-radius: 8px;
+            cursor: pointer;
+            transition: background-color 0.2s, transform 0.1s;
+        }
+
+        .btn:active {
+            transform: scale(0.98);
+        }
+
+        .btn-primary {
+            background-color: var(--primary-color);
+            color: white;
+        }
+
+        .btn-primary:hover {
+            background-color: #0288d1;
+        }
+
+        .btn-primary:disabled {
+            background-color: #555;
+            cursor: not-allowed;
+        }
+
+        .btn-secondary {
+            background-color: transparent;
+            color: var(--text-secondary);
+            border: 1px solid var(--text-secondary);
+            margin-top: 12px;
+        }
+
+        .btn-secondary:hover {
+            background-color: rgba(255, 255, 255, 0.05);
+        }
+
+        .instructions {
+            margin-top: 24px;
+            padding-top: 24px;
+            border-top: 1px solid rgba(255, 255, 255, 0.1);
+        }
+
+        .instructions h3 {
+            font-size: 14px;
+            font-weight: 500;
+            margin-bottom: 12px;
+        }
+
+        .instructions ol {
+            padding-left: 20px;
+            color: var(--text-secondary);
+            font-size: 13px;
+            line-height: 1.8;
+        }
+
+        .success-icon {
+            display: inline-block;
+            color: var(--success-color);
+            margin-right: 8px;
+        }
+
+        .error-icon {
+            display: inline-block;
+            color: var(--error-color);
+            margin-right: 8px;
+        }
+    </style>
+</head>
+<body>
+    <div class="container">
+        <div class="card">
+            <div class="header">
+                <h1>Carelink Token Generator</h1>
+                <p>Generate login tokens for the Carelink integration</p>
+                <span class="region-badge">Region: {{ region | upper }}</span>
+            </div>
+
+            <div id="status" class="status-container status-idle">
+                <div class="status-label">Status</div>
+                <div class="status-message" id="status-message">
+                    Ready to start authentication
+                </div>
+            </div>
+
+            <button id="start-btn" class="btn btn-primary" onclick="startAuth()">
+                Start Login Process
+            </button>
+
+            <button id="reset-btn" class="btn btn-secondary" onclick="resetAuth()" style="display: none;">
+                Start Over
+            </button>
+
+            <div class="instructions">
+                <h3>How it works:</h3>
+                <ol>
+                    <li>Click "Start Login Process"</li>
+                    <li>A browser window will open automatically</li>
+                    <li>Log in with your Carelink credentials</li>
+                    <li>The tokens will be saved automatically</li>
+                    <li>Add the Carelink integration with empty fields</li>
+                </ol>
+            </div>
+        </div>
+    </div>
+
+    <script>
+        let pollInterval = null;
+
+        function startAuth() {
+            const btn = document.getElementById('start-btn');
+            btn.disabled = true;
+            btn.textContent = 'Starting...';
+
+            fetch('/start', { method: 'POST' })
+                .then(response => response.json())
+                .then(data => {
+                    if (data.status === 'started') {
+                        pollStatus();
+                    }
+                })
+                .catch(error => {
+                    console.error('Error:', error);
+                    btn.disabled = false;
+                    btn.textContent = 'Start Login Process';
+                });
+        }
+
+        function pollStatus() {
+            if (pollInterval) clearInterval(pollInterval);
+
+            pollInterval = setInterval(() => {
+                fetch('/status')
+                    .then(response => response.json())
+                    .then(data => {
+                        updateUI(data);
+
+                        if (data.status === 'success' || data.status === 'error') {
+                            clearInterval(pollInterval);
+                            pollInterval = null;
+                        }
+                    })
+                    .catch(error => console.error('Poll error:', error));
+            }, 1000);
+        }
+
+        function updateUI(data) {
+            const statusDiv = document.getElementById('status');
+            const statusMessage = document.getElementById('status-message');
+            const startBtn = document.getElementById('start-btn');
+            const resetBtn = document.getElementById('reset-btn');
+
+            // Remove all status classes
+            statusDiv.className = 'status-container';
+
+            switch (data.status) {
+                case 'idle':
+                    statusDiv.classList.add('status-idle');
+                    statusMessage.innerHTML = 'Ready to start authentication';
+                    startBtn.disabled = false;
+                    startBtn.textContent = 'Start Login Process';
+                    startBtn.style.display = 'block';
+                    resetBtn.style.display = 'none';
+                    break;
+
+                case 'running':
+                    statusDiv.classList.add('status-running');
+                    statusMessage.innerHTML = '<span class="spinner"></span>' + data.message;
+                    startBtn.disabled = true;
+                    startBtn.textContent = 'Authentication in progress...';
+                    startBtn.style.display = 'block';
+                    resetBtn.style.display = 'none';
+                    break;
+
+                case 'success':
+                    statusDiv.classList.add('status-success');
+                    statusMessage.innerHTML = '<span class="success-icon">✓</span>' + data.message;
+                    startBtn.style.display = 'none';
+                    resetBtn.style.display = 'block';
+                    break;
+
+                case 'error':
+                    statusDiv.classList.add('status-error');
+                    statusMessage.innerHTML = '<span class="error-icon">✗</span>' + data.message;
+                    startBtn.style.display = 'none';
+                    resetBtn.style.display = 'block';
+                    break;
+            }
+        }
+
+        function resetAuth() {
+            fetch('/reset', { method: 'POST' })
+                .then(response => response.json())
+                .then(data => {
+                    updateUI({ status: 'idle', message: '' });
+                });
+        }
+
+        // Initial status check
+        fetch('/status')
+            .then(response => response.json())
+            .then(data => updateUI(data));
+    </script>
+</body>
+</html>

--- a/carelink-token-generator/rootfs/run.sh
+++ b/carelink-token-generator/rootfs/run.sh
@@ -1,0 +1,17 @@
+#!/usr/bin/env bash
+set -e
+
+echo "Starting Carelink Token Generator..."
+
+# Start virtual display for headless Firefox
+echo "Starting Xvfb virtual display..."
+Xvfb :99 -screen 0 1024x768x24 &
+export DISPLAY=:99
+
+# Wait for display to be ready
+sleep 2
+
+# Start the Flask web server
+echo "Starting web server on port 8099..."
+cd /app
+exec python3 server.py

--- a/carelink-token-generator/translations/en.yaml
+++ b/carelink-token-generator/translations/en.yaml
@@ -1,0 +1,4 @@
+configuration:
+  region:
+    name: Region
+    description: Select your Carelink region (EU or US)

--- a/repository.yaml
+++ b/repository.yaml
@@ -1,0 +1,3 @@
+name: Carelink Home Assistant Add-ons
+url: https://github.com/yo-han/Home-Assistant-Carelink
+maintainer: Johan Kuijt <github@johankuijt.com>


### PR DESCRIPTION
## Summary
- Adds a new Home Assistant add-on for generating Carelink login tokens
- Provides a web UI accessible from the HA sidebar for non-technical users
- Supports both EU and US Carelink regions
- Updates documentation to recommend add-on as primary option

## Features
- Flask-based web interface with dark theme matching HA
- Headless Firefox with Selenium for OAuth flow
- Automatic token file placement in HA config directory
- Status polling and error handling in UI

## Files Added
- `repository.yaml` - Add-on repository configuration
- `carelink-token-generator/` - Full add-on structure:
  - `config.yaml` - Add-on configuration
  - `Dockerfile` - Container build instructions
  - `rootfs/` - Application files (Flask server, auth module, templates)
  - `README.md` - Add-on documentation
