### PR TITLE
Handle shared seed token refresh

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,9 +29,9 @@ Copy the `custom_components/carelink` to your `custom_components` folder. Reboot
 ## Integration Setup
 
 ### Carelink Login Data
-The needed information for the authentification process can either be provided as file (=logindata.json), or entered during the initial setup of the integration.
+The needed information for the authentification process can either be provided as a shared seed file (`/config/carelink_logindata.json`), or entered during the initial setup of the integration.
 #### Get the data
-The Home Assistant Carelink Integration needs the initial login data stored in the `logindata.json` file. There are three ways to create this file:
+The Home Assistant Carelink Integration needs the initial login data stored in `/config/carelink_logindata.json` (shared seed). There are three ways to create this file:
 
 ##### Option 1: Home Assistant Add-on (Recommended)
 
@@ -48,7 +48,7 @@ The easiest way to get your `logindata.json` is using the Carelink Token Generat
 
 4. Click "Open Web UI" and follow the login process
 
-5. The token file will be saved automatically - you can then add the Carelink integration with empty fields
+5. The token file will be saved automatically to `/config/carelink_logindata.json` - you can then add the Carelink integration with empty fields
 
 For more details, see the [Add-on README](carelink-token-generator/README.md).
 
@@ -73,6 +73,7 @@ If you can't use the Home Assistant add-on, you can use our Docker-based token t
 4. **Wait a few seconds** for your credentials to be auto-filled, then solve the CAPTCHA
 
 5. Download your token file from `http://localhost:8000/logindata.json` or find it in `./token-tool/output/`
+6. Copy it to your Home Assistant config directory as `/config/carelink_logindata.json`
 
 For more details and troubleshooting, see the [Token Tool README](token-tool/README.md).
 
@@ -110,12 +111,15 @@ On successful completion of the login, the data file will be created with the fo
 ![grafik](https://github.com/sedy89/Home-Assistant-Carelink/assets/65983953/35a60542-03fc-4deb-a14c-c96b0155bdd4)
 
 #### Provide the data
-Either the content of the `logindata.json` file can be taken over into the setup of the HA Carelink integration, or the entire file can be uploaded into the custom_componend/carelink folder (recommended).
+Either the content of the `logindata.json` file can be taken over into the setup of the HA Carelink integration, or the entire file can be placed at `/config/carelink_logindata.json` (shared seed).
 
 ![grafik](https://github.com/sedy89/Home-Assistant-Carelink/assets/65983953/0a1d8773-7905-4fec-9bff-b3a0f01817b9)
 
-All parameters during setup are optional and a provided file will have a higher priority and overwrite the manual configuration.
-If the file was copied to `custom_components/carelink` before the integration setup was started in Home Assistant, all parameters during the setup can stay empty.
+All parameters during setup are optional and a provided shared seed file will have a higher priority and overwrite the manual configuration.
+If the file was placed at `/config/carelink_logindata.json` before the integration setup was started in Home Assistant, all parameters during the setup can stay empty.
+The integration will copy the shared seed into an entry-specific file at `/config/carelink_logindata_<entry_id>.json`.
+If you regenerate tokens, the integration will update the entry-specific file when the shared seed is newer.
+Legacy installs that still use `custom_components/carelink/logindata.json` will be handled as a fallback.
 With those information, the Home Assistant Carelink Integration will be able to automatically refresh the login data when it expires.
 It should be able to do so within one week of the last refresh.
 

--- a/carelink-token-generator/README.md
+++ b/carelink-token-generator/README.md
@@ -4,7 +4,7 @@ A Home Assistant add-on that provides a web interface for generating Carelink lo
 
 ## About
 
-This add-on makes it easy for non-technical users to generate the `logindata.json` file required by the [Carelink Integration](https://github.com/yo-han/Home-Assistant-Carelink). No Python or Docker knowledge required.
+This add-on makes it easy for non-technical users to generate the `/config/carelink_logindata.json` shared seed file required by the [Carelink Integration](https://github.com/yo-han/Home-Assistant-Carelink). No Python or Docker knowledge required.
 
 ## Features
 
@@ -42,7 +42,7 @@ After generating the token:
 1. Go to **Settings** → **Devices & Services** → **Add Integration**
 2. Search for "Carelink"
 3. Leave the username and password fields empty
-4. The integration will automatically use the generated token file
+4. The integration will automatically use the generated token file and copy it to an entry-specific file
 
 ## Configuration
 
@@ -74,6 +74,8 @@ This add-on runs:
 - Firefox with Selenium for OAuth flow automation
 
 The generated token file is saved to `/config/carelink_logindata.json` which is the Home Assistant config directory.
+The integration will copy this shared seed to `/config/carelink_logindata_<entry_id>.json` on first setup.
+If you regenerate tokens, the integration will update the entry-specific file when the shared seed is newer.
 
 ## Support
 

--- a/custom_components/carelink/__init__.py
+++ b/custom_components/carelink/__init__.py
@@ -16,7 +16,7 @@ from homeassistant.helpers.update_coordinator import (
     DataUpdateCoordinator,
 )
 
-from .api import CarelinkClient, LEGACY_AUTH_FILE, AUTH_FILE_PREFIX
+from .api import CarelinkClient, LEGACY_AUTH_FILE, AUTH_FILE_PREFIX, SHARED_AUTH_FILE
 from .nightscout_uploader import NightscoutUploader
 
 from .const import (
@@ -120,29 +120,60 @@ def convert_date_to_isodate(date):
 def _migrate_legacy_logindata(config_path: str, entry_id: str) -> None:
     """Migrate logindata.json from old location to new entry-specific location.
 
-    Old location: custom_components/carelink/logindata.json (relative to config)
-    New location: {config_path}/carelink_logindata_{entry_id}.json
+    Priority order for source:
+    1. Shared location: {config_path}/carelink_logindata.json (token generator add-on)
+    2. Legacy location: custom_components/carelink/logindata.json
+
+    Target: {config_path}/carelink_logindata_{entry_id}.json
+
+    Note: Source files are NOT deleted after migration to serve as fallback
+    if the entry-specific location becomes unavailable.
     """
-    old_path = os.path.join(config_path, LEGACY_AUTH_FILE)
     new_filename = f"{AUTH_FILE_PREFIX}_{entry_id}.json"
     new_path = os.path.join(config_path, new_filename)
 
-    # Only migrate if old file exists and new file doesn't
-    if os.path.exists(old_path) and not os.path.exists(new_path):
+    # If entry-specific file already exists, no migration needed
+    if os.path.exists(new_path):
+        _LOGGER.debug("Entry-specific logindata already exists: %s", new_path)
+        return
+
+    shared_path = os.path.join(config_path, SHARED_AUTH_FILE)
+    legacy_path = os.path.join(config_path, LEGACY_AUTH_FILE)
+
+    # Try shared location first (token generator add-on writes here)
+    if os.path.exists(shared_path):
         try:
-            shutil.copy2(old_path, new_path)
+            shutil.copy(shared_path, new_path)
             _LOGGER.info(
-                "Migrated logindata from %s to %s",
-                old_path,
+                "Copied logindata from shared location %s to %s",
+                shared_path,
                 new_path
             )
-            # Remove old file after successful migration
-            os.remove(old_path)
-            _LOGGER.debug("Removed legacy logindata file: %s", old_path)
+            return
         except OSError as error:
             _LOGGER.warning(
-                "Failed to migrate logindata from %s to %s: %s",
-                old_path,
+                "Failed to copy logindata from %s to %s: %s. "
+                "Will use fallback location at runtime.",
+                shared_path,
+                new_path,
+                error
+            )
+
+    # Try legacy location (old installations)
+    if os.path.exists(legacy_path):
+        try:
+            shutil.copy(legacy_path, new_path)
+            _LOGGER.info(
+                "Migrated logindata from legacy location %s to %s",
+                legacy_path,
+                new_path
+            )
+            return
+        except OSError as error:
+            _LOGGER.warning(
+                "Failed to migrate logindata from %s to %s: %s. "
+                "Will use fallback location at runtime.",
+                legacy_path,
                 new_path,
                 error
             )

--- a/custom_components/carelink/api.py
+++ b/custom_components/carelink/api.py
@@ -34,6 +34,7 @@ VERSION = "0.4"
 AUTH_EXPIRE_DEADLINE_MINUTES = 10
 AUTH_FILE_PREFIX = "carelink_logindata"
 LEGACY_AUTH_FILE = "custom_components/carelink/logindata.json"
+SHARED_AUTH_FILE = f"{AUTH_FILE_PREFIX}.json"
 CARELINK_CONFIG_URL = "https://clcloud.minimed.eu/connect/carepartner/v13/discover/android/3.6"
 AUTH_ERROR_CODES = [401,403]
 
@@ -87,9 +88,11 @@ class CarelinkClient:
         if config_path:
             self.__auth_file_path = os.path.join(config_path, auth_filename)
             self.__legacy_auth_file_path = os.path.join(config_path, LEGACY_AUTH_FILE)
+            self.__shared_auth_file_path = os.path.join(config_path, SHARED_AUTH_FILE)
         else:
             self.__auth_file_path = auth_filename
             self.__legacy_auth_file_path = LEGACY_AUTH_FILE
+            self.__shared_auth_file_path = SHARED_AUTH_FILE
         self.__session_user = None
         self.__session_username = None
         self.__session_config = None
@@ -465,52 +468,109 @@ class CarelinkClient:
         return None
 
     async def _write_token_file(self, obj, filename):
-        printdbg("_write_token_file()")
-        directory = os.path.dirname(filename)
-        if directory:
-            await asyncio.to_thread(os.makedirs, directory, exist_ok=True)
-        async with aiofiles.open(filename, 'w') as f:
-            await f.write(json.dumps(obj, indent=4))
+        printdbg(f"_write_token_file() -> {filename}")
+        try:
+            directory = os.path.dirname(filename)
+            if directory:
+                await asyncio.to_thread(os.makedirs, directory, exist_ok=True)
+            async with aiofiles.open(filename, 'w') as f:
+                await f.write(json.dumps(obj, indent=4))
+            printdbg("Token file written successfully")
+            return True
+        except (OSError, IOError) as error:
+            printdbg(f"ERROR: Failed to write token file {filename}: {error}")
+            return False
+
+    def _has_required_token_fields(self, token_data):
+        if token_data is None:
+            return False
+        required_fields = ["access_token", "refresh_token", "client_id"]
+        return all(field in token_data for field in required_fields)
+
+    async def _load_shared_seed_if_newer(self, filename):
+        try:
+            shared_mtime = os.path.getmtime(self.__shared_auth_file_path)
+            entry_mtime = os.path.getmtime(filename)
+        except FileNotFoundError:
+            return None
+        except OSError as error:
+            printdbg(f"ERROR: failed checking token file timestamps: {error}")
+            return None
+
+        if shared_mtime <= entry_mtime:
+            return None
+
+        try:
+            async with aiofiles.open(self.__shared_auth_file_path, mode="r") as f:
+                token_data = json.loads(await f.read())
+        except FileNotFoundError:
+            return None
+        except (OSError, json.JSONDecodeError) as error:
+            printdbg(f"ERROR: failed parsing shared token file: {error}")
+            return None
+
+        if not self._has_required_token_fields(token_data):
+            printdbg("ERROR: shared token file is missing required fields")
+            return None
+
+        printdbg("Shared token file is newer than entry-specific file; using shared seed")
+        return token_data
 
     async def _process_token_file(self, filename):
         printdbg("_process_token_file()")
         token_data = None
         file_exists = False
         used_legacy = False
+        used_shared = False
         try:
             async with aiofiles.open(filename, mode="r") as f:
                 token_data = json.loads(await f.read())
                 file_exists = True
+                shared_seed = await self._load_shared_seed_if_newer(filename)
+                if shared_seed is not None:
+                    token_data = shared_seed
+                    used_shared = True
         except FileNotFoundError:
-            printdbg(f"Authentification file {filename} does not exist.")
-            # Try legacy location as fallback
+            printdbg(f"Entry-specific auth file {filename} does not exist.")
+            # Try shared location first (token generator add-on writes here)
             try:
-                async with aiofiles.open(self.__legacy_auth_file_path, mode="r") as f:
+                async with aiofiles.open(self.__shared_auth_file_path, mode="r") as f:
                     token_data = json.loads(await f.read())
                     file_exists = True
-                    used_legacy = True
-                    printdbg(f"Found token file at legacy location: {self.__legacy_auth_file_path}")
+                    used_shared = True
+                    printdbg(f"Found shared token file at: {self.__shared_auth_file_path}")
             except FileNotFoundError:
-                printdbg(f"Legacy auth file {self.__legacy_auth_file_path} also does not exist.")
+                printdbg(f"Shared auth file {self.__shared_auth_file_path} does not exist.")
             except (OSError, json.JSONDecodeError) as error:
-                printdbg(f"ERROR: failed parsing legacy token file: {error}")
+                printdbg(f"ERROR: failed parsing shared token file: {error}")
+            # Try legacy location as fallback (old installations)
+            if not file_exists:
+                try:
+                    async with aiofiles.open(self.__legacy_auth_file_path, mode="r") as f:
+                        token_data = json.loads(await f.read())
+                        file_exists = True
+                        used_legacy = True
+                        printdbg(f"Found token file at legacy location: {self.__legacy_auth_file_path}")
+                except FileNotFoundError:
+                    printdbg(f"Legacy auth file {self.__legacy_auth_file_path} also does not exist.")
+                except (OSError, json.JSONDecodeError) as error:
+                    printdbg(f"ERROR: failed parsing legacy token file: {error}")
         except (OSError, json.JSONDecodeError) as error:
             printdbg(f"ERROR: failed parsing token file {filename}: {error}")
             file_exists = True  # File exists but failed to parse
 
         if file_exists:
             cfg_complete = True
-            if token_data is not None:
-                required_fields = ["access_token", "refresh_token", "client_id"]
-                for field in required_fields:
+            if token_data is not None and not self._has_required_token_fields(token_data):
+                for field in ["access_token", "refresh_token", "client_id"]:
                     if field not in token_data:
                         printdbg(f"ERROR: field {field} is missing from token file")
-                        cfg_complete = False
+                cfg_complete = False
             if not cfg_complete:
                 token_data = None
-            elif used_legacy and token_data is not None:
-                # Copy token from legacy location to new location for future use
-                printdbg(f"Copying token from legacy location to {filename}")
+            elif token_data is not None and (used_legacy or used_shared):
+                # Copy token from legacy/shared location to new location for future use
+                printdbg(f"Copying token from fallback location to {filename}")
                 await self._write_token_file(token_data, filename)
         else:
             if self.__carelink_access_token and self.__carelink_refresh_token and self.__client_id:
@@ -531,6 +591,16 @@ class CarelinkClient:
     # Authentication methods
     async def login(self):
         """perform login"""
+        if self.__initialized:
+            shared_seed = await self._load_shared_seed_if_newer(self.__auth_file_path)
+            if shared_seed is not None:
+                self.__token_data = shared_seed
+                await self._write_token_file(shared_seed, self.__auth_file_path)
+                self.__session_user = None
+                self.__session_username = None
+                self.__session_config = None
+                self.__session_country = None
+                self.__initialized = False
         if not self.__initialized:
             await self.__execute_init_procedure()
         return self.__initialized

--- a/token-tool/README.md
+++ b/token-tool/README.md
@@ -49,7 +49,7 @@ Open `http://localhost:6080/vnc.html?autoconnect=true` and enter credentials man
 3. **Wait a few seconds** for credentials to be auto-filled (if configured)
 4. **Solve the CAPTCHA** and complete the login
 5. **Download your tokens**: `http://localhost:8000/logindata.json` (or find in `./output/`)
-6. **Copy to Home Assistant**: Place `logindata.json` in `custom_components/carelink/`
+6. **Copy to Home Assistant**: Place the file at `/config/carelink_logindata.json` (shared seed)
 
 ## Region Selection
 
@@ -57,6 +57,15 @@ For **US region**, add to your `.env` file:
 
 ```bash
 CARELINK_REGION=us
+```
+
+## Output Path
+
+By default the tool writes `logindata.json` locally. To write directly to a different
+location (for example a mounted Home Assistant config directory), set:
+
+```bash
+CARELINK_OUTPUT_FILE=/config/carelink_logindata.json
 ```
 
 ## Docker Commands

--- a/token-tool/carelink_login.py
+++ b/token-tool/carelink_login.py
@@ -417,7 +417,7 @@ def read_data_file(file):
 
 def main():
     # Configuration
-    logindata_file = 'logindata.json'
+    default_logindata_file = "logindata.json"
     discovery_url = 'https://clcloud.minimed.eu/connect/carepartner/v13/discover/android/3.6'
     rsa_keysize = 2048
 
@@ -425,11 +425,19 @@ def main():
     parser = argparse.ArgumentParser(description='Carelink Token Tool')
     parser.add_argument('--us', help='Use US region (default: EU)',
                         default=False, action='store_true')
+    parser.add_argument(
+        "--output",
+        help="Output path for logindata.json (env: CARELINK_OUTPUT_FILE)",
+        default=None,
+    )
     args = parser.parse_args()
 
     # Also check environment variable (support multiple formats)
     region_env = os.environ.get('CARELINK_REGION', '').lower().strip()
     is_us_region = args.us or region_env in ('--us', 'us', 'true', '1')
+
+    output_env = os.environ.get("CARELINK_OUTPUT_FILE", "").strip()
+    logindata_file = output_env or args.output or default_logindata_file
 
     print("\n" + "=" * 50)
     print("   CARELINK TOKEN TOOL")
@@ -442,7 +450,7 @@ def main():
 
     if token_data is not None:
         print("\nExisting token file found!")
-        print("Delete logindata.json to generate new tokens.")
+        print(f"Delete {os.path.basename(logindata_file)} to generate new tokens.")
         return
 
     print("\nStarting login process...")


### PR DESCRIPTION
## Summary
- copy shared seed token file into entry-specific file when missing
- auto-reseed entry tokens when shared seed is newer
- align docs and token tool output path with shared seed model
