### PR TITLE
Initial Test validation required

### DIFF
--- a/custom_components/carelink/__init__.py
+++ b/custom_components/carelink/__init__.py
@@ -1,4 +1,4 @@
-"""Medtronic arelink integration."""
+"""Medtronic Carelink / Tandem t:slim integration."""
 from __future__ import annotations
 
 import logging
@@ -17,18 +17,24 @@ from homeassistant.helpers.update_coordinator import (
 )
 
 from .api import CarelinkClient, LEGACY_AUTH_FILE, AUTH_FILE_PREFIX, SHARED_AUTH_FILE
+from .tandem_api import TandemSourceClient, parse_dotnet_date
 from .nightscout_uploader import NightscoutUploader
 
 from .const import (
     CLIENT,
+    TANDEM_CLIENT,
     UPLOADER,
     DOMAIN,
     SCAN_INTERVAL,
     COORDINATOR,
     UNAVAILABLE,
+    PLATFORM_TYPE,
+    PLATFORM_CARELINK,
+    PLATFORM_TANDEM,
     DEVICE_PUMP_MODEL,
     DEVICE_PUMP_NAME,
     DEVICE_PUMP_SERIAL,
+    DEVICE_PUMP_MANUFACTURER,
     SENSOR_KEY_PUMP_BATTERY_LEVEL,
     SENSOR_KEY_CONDUIT_BATTERY_LEVEL,
     SENSOR_KEY_SENSOR_BATTERY_LEVEL,
@@ -82,6 +88,28 @@ from .const import (
     MS_TIMEZONE_TO_IANA_MAP,
     SENSOR_KEY_TIME_TO_NEXT_CALIB_HOURS,
     CARELINK_CODE_MAP,
+    # Tandem sensor keys
+    TANDEM_SENSOR_KEY_LASTSG_MMOL,
+    TANDEM_SENSOR_KEY_LASTSG_MGDL,
+    TANDEM_SENSOR_KEY_LASTSG_TIMESTAMP,
+    TANDEM_SENSOR_KEY_SG_DELTA,
+    TANDEM_SENSOR_KEY_LAST_BOLUS_UNITS,
+    TANDEM_SENSOR_KEY_LAST_BOLUS_TIMESTAMP,
+    TANDEM_SENSOR_KEY_LAST_BOLUS_ATTRS,
+    TANDEM_SENSOR_KEY_BASAL_RATE,
+    TANDEM_SENSOR_KEY_ACTIVE_INSULIN,
+    TANDEM_SENSOR_KEY_LAST_UPLOAD,
+    TANDEM_SENSOR_KEY_SOFTWARE_VERSION,
+    TANDEM_SENSOR_KEY_PUMP_SERIAL_INFO,
+    TANDEM_SENSOR_KEY_PUMP_MODEL_INFO,
+    TANDEM_SENSOR_KEY_AVG_GLUCOSE_MMOL,
+    TANDEM_SENSOR_KEY_AVG_GLUCOSE_MGDL,
+    TANDEM_SENSOR_KEY_TIME_IN_RANGE as TANDEM_TIME_IN_RANGE,
+    TANDEM_SENSOR_KEY_CGM_USAGE,
+    TANDEM_SENSOR_KEY_CONTROL_IQ_STATUS,
+    TANDEM_SENSOR_KEY_UPDATE_TIMESTAMP,
+    TANDEM_SENSOR_KEY_LAST_MEAL_BOLUS,
+    TANDEM_SENSOR_KEY_LAST_MEAL_BOLUS_ATTRS,
 )
 
 PLATFORMS: list[Platform] = [Platform.SENSOR, Platform.BINARY_SENSOR]
@@ -94,6 +122,7 @@ PII_FIELDS = {
     "firstName", "lastName", "username", "patientId", "conduitSerialNumber",
     "medicalDeviceSerialNumber", "systemId", "email", "phone", "emailAddress",
     "phoneNumber", "address", "dateOfBirth", "dob", "deviceSerialNumber",
+    "patientName", "patientDateOfBirth", "patientCareGiver",
 }
 
 
@@ -184,10 +213,21 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
 
     hass.data.setdefault(DOMAIN, {})
 
+    config = entry.data
+    platform_type = config.get(PLATFORM_TYPE, PLATFORM_CARELINK)
+
+    if platform_type == PLATFORM_TANDEM:
+        return await _async_setup_tandem_entry(hass, entry, config)
+    else:
+        return await _async_setup_carelink_entry(hass, entry, config)
+
+
+async def _async_setup_carelink_entry(
+    hass: HomeAssistant, entry: ConfigEntry, config: dict
+) -> bool:
+    """Set up a Medtronic Carelink config entry."""
     # Migrate logindata from old location if needed
     _migrate_legacy_logindata(hass.config.path(), entry.entry_id)
-
-    config = entry.data
 
     carelink_client = CarelinkClient(
         config["cl_refresh_token"],
@@ -200,16 +240,56 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
         entry_id=entry.entry_id
     )
 
-    hass.data.setdefault(DOMAIN, {})[entry.entry_id] = {CLIENT: carelink_client}
+    hass.data.setdefault(DOMAIN, {})[entry.entry_id] = {
+        CLIENT: carelink_client,
+        PLATFORM_TYPE: PLATFORM_CARELINK,
+    }
 
-    if config["nightscout_url"] and config["nightscout_api"]:
+    if config.get("nightscout_url") and config.get("nightscout_api"):
         nightscout_uploader = NightscoutUploader(
             config["nightscout_url"],
             config["nightscout_api"]
         )
-        hass.data.setdefault(DOMAIN, {})[entry.entry_id].update({UPLOADER: nightscout_uploader})
+        hass.data[DOMAIN][entry.entry_id][UPLOADER] = nightscout_uploader
 
-    coordinator = CarelinkCoordinator(hass, entry, update_interval=timedelta(seconds=config[SCAN_INTERVAL]))
+    coordinator = CarelinkCoordinator(
+        hass, entry, update_interval=timedelta(seconds=config[SCAN_INTERVAL])
+    )
+
+    await coordinator.async_config_entry_first_refresh()
+
+    hass.data[DOMAIN][entry.entry_id][COORDINATOR] = coordinator
+
+    await hass.config_entries.async_forward_entry_setups(entry, PLATFORMS)
+
+    return True
+
+
+async def _async_setup_tandem_entry(
+    hass: HomeAssistant, entry: ConfigEntry, config: dict
+) -> bool:
+    """Set up a Tandem t:slim Source config entry."""
+    tandem_client = TandemSourceClient(
+        email=config["tandem_email"],
+        password=config["tandem_password"],
+        region=config.get("tandem_region", "EU"),
+    )
+
+    hass.data.setdefault(DOMAIN, {})[entry.entry_id] = {
+        TANDEM_CLIENT: tandem_client,
+        PLATFORM_TYPE: PLATFORM_TANDEM,
+    }
+
+    if config.get("nightscout_url") and config.get("nightscout_api"):
+        nightscout_uploader = NightscoutUploader(
+            config["nightscout_url"],
+            config["nightscout_api"]
+        )
+        hass.data[DOMAIN][entry.entry_id][UPLOADER] = nightscout_uploader
+
+    coordinator = TandemCoordinator(
+        hass, entry, update_interval=timedelta(seconds=config[SCAN_INTERVAL])
+    )
 
     await coordinator.async_config_entry_first_refresh()
 
@@ -231,6 +311,11 @@ async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
                 await entry_data[CLIENT].close()
             except Exception as error:
                 _LOGGER.warning("Failed to close Carelink client: %s", error)
+        if TANDEM_CLIENT in entry_data:
+            try:
+                await entry_data[TANDEM_CLIENT].close()
+            except Exception as error:
+                _LOGGER.warning("Failed to close Tandem client: %s", error)
         if UPLOADER in entry_data:
             try:
                 await entry_data[UPLOADER].close()
@@ -240,8 +325,12 @@ async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     return unload_ok
 
 
+# ═══════════════════════════════════════════════════════════════════════════
+# Carelink (Medtronic) Coordinator
+# ═══════════════════════════════════════════════════════════════════════════
+
 class CarelinkCoordinator(DataUpdateCoordinator):
-    """Class to manage fetching data from the API."""
+    """Class to manage fetching data from the Carelink API."""
 
     def __init__(self, hass: HomeAssistant, entry, update_interval: timedelta):
 
@@ -392,7 +481,7 @@ class CarelinkCoordinator(DataUpdateCoordinator):
                     last_alarm["messageId"] = str(fault_id)
             else:
                 last_alarm["messageId"] = "UNKNOWN"
-            
+
             data[SENSOR_KEY_LAST_ALARM] = date_time_local.replace(tzinfo=timezone)
             data[SENSOR_KEY_LAST_ALARM_ATTRS] = last_alarm
             active_notification = get_active_notification(last_alarm, recent_data["notificationHistory"])
@@ -428,7 +517,7 @@ class CarelinkCoordinator(DataUpdateCoordinator):
         else:
             data[SENSOR_KEY_AVG_GLUCOSE_MMOL] = UNAVAILABLE
             data[SENSOR_KEY_AVG_GLUCOSE_MGDL] = UNAVAILABLE
-            
+
         data[SENSOR_KEY_BELOW_HYPO_LIMIT] = recent_data.setdefault(
             "belowHypoLimit", UNAVAILABLE
         )
@@ -536,6 +625,7 @@ class CarelinkCoordinator(DataUpdateCoordinator):
             + recent_data.setdefault("lastName", "Unvailable")
         )
         data[DEVICE_PUMP_MODEL] = recent_data.setdefault("pumpModelNumber", UNAVAILABLE)
+        data[DEVICE_PUMP_MANUFACTURER] = "Medtronic"
 
         data[SENSOR_KEY_APP_MODEL_TYPE] = recent_data.setdefault(
             "appModelType", UNAVAILABLE
@@ -567,6 +657,326 @@ class CarelinkCoordinator(DataUpdateCoordinator):
         _LOGGER.debug("_async_update_data: %s", sanitize_for_logging(data))
 
         return data
+
+
+# ═══════════════════════════════════════════════════════════════════════════
+# Tandem t:slim Coordinator
+# ═══════════════════════════════════════════════════════════════════════════
+
+class TandemCoordinator(DataUpdateCoordinator):
+    """Class to manage fetching data from the Tandem Source API."""
+
+    def __init__(self, hass: HomeAssistant, entry, update_interval: timedelta):
+        super().__init__(hass, _LOGGER, name=DOMAIN, update_interval=update_interval)
+
+        self.uploader = None
+        self.client = hass.data[DOMAIN][entry.entry_id][TANDEM_CLIENT]
+        self.timezone = hass.config.time_zone
+        self._prev_sg_mgdl: float | None = None
+
+        if UPLOADER in hass.data[DOMAIN][entry.entry_id]:
+            self.uploader = hass.data[DOMAIN][entry.entry_id][UPLOADER]
+
+    async def _async_update_data(self):
+        data = {}
+
+        await self.client.login()
+        recent_data = await self.client.get_recent_data()
+
+        _LOGGER.debug(
+            "Tandem before data parsing: %s", sanitize_for_logging(recent_data)
+        )
+
+        # ── Device info from pump metadata ───────────────────────────────
+        metadata = recent_data.get("pump_metadata")
+        pumper_info = recent_data.get("pumper_info")
+
+        if metadata:
+            data[DEVICE_PUMP_SERIAL] = metadata.get("serialNumber", "unknown")
+            data[DEVICE_PUMP_MODEL] = metadata.get("modelNumber", "t:slim X2")
+            data[DEVICE_PUMP_NAME] = metadata.get("patientName", "Tandem Pump")
+            data[TANDEM_SENSOR_KEY_PUMP_SERIAL_INFO] = metadata.get("serialNumber")
+            data[TANDEM_SENSOR_KEY_PUMP_MODEL_INFO] = metadata.get("modelNumber")
+            data[TANDEM_SENSOR_KEY_SOFTWARE_VERSION] = metadata.get("softwareVersion")
+
+            # Parse last upload timestamp
+            last_upload = metadata.get("lastUpload")
+            if last_upload:
+                upload_dt = parse_dotnet_date(last_upload)
+                if upload_dt:
+                    data[TANDEM_SENSOR_KEY_LAST_UPLOAD] = upload_dt.replace(
+                        tzinfo=ZoneInfo(self.timezone)
+                    )
+                    data[TANDEM_SENSOR_KEY_UPDATE_TIMESTAMP] = upload_dt.replace(
+                        tzinfo=ZoneInfo(self.timezone)
+                    )
+                else:
+                    data[TANDEM_SENSOR_KEY_LAST_UPLOAD] = UNAVAILABLE
+                    data[TANDEM_SENSOR_KEY_UPDATE_TIMESTAMP] = UNAVAILABLE
+            else:
+                data[TANDEM_SENSOR_KEY_LAST_UPLOAD] = UNAVAILABLE
+                data[TANDEM_SENSOR_KEY_UPDATE_TIMESTAMP] = UNAVAILABLE
+        else:
+            data[DEVICE_PUMP_SERIAL] = "unknown"
+            data[DEVICE_PUMP_MODEL] = "t:slim X2"
+            data[DEVICE_PUMP_NAME] = "Tandem Pump"
+            data[TANDEM_SENSOR_KEY_PUMP_SERIAL_INFO] = UNAVAILABLE
+            data[TANDEM_SENSOR_KEY_PUMP_MODEL_INFO] = UNAVAILABLE
+            data[TANDEM_SENSOR_KEY_SOFTWARE_VERSION] = UNAVAILABLE
+            data[TANDEM_SENSOR_KEY_LAST_UPLOAD] = UNAVAILABLE
+            data[TANDEM_SENSOR_KEY_UPDATE_TIMESTAMP] = UNAVAILABLE
+
+        data[DEVICE_PUMP_MANUFACTURER] = "Tandem Diabetes Care"
+
+        # Override name from pumper info if available
+        if pumper_info:
+            first = pumper_info.get("firstName", "")
+            last = pumper_info.get("lastName", "")
+            name = f"{first} {last}".strip()
+            if name:
+                data[DEVICE_PUMP_NAME] = name
+
+        # ── Therapy timeline (CGM, bolus, basal) ────────────────────────
+        timeline = recent_data.get("therapy_timeline")
+        self._parse_therapy_timeline(timeline, data)
+
+        # ── Dashboard summary (statistics) ───────────────────────────────
+        summary = recent_data.get("dashboard_summary")
+        self._parse_dashboard_summary(summary, data)
+
+        _LOGGER.debug(
+            "Tandem _async_update_data: %s", sanitize_for_logging(data)
+        )
+
+        return data
+
+    def _parse_therapy_timeline(self, timeline: dict | None, data: dict) -> None:
+        """Parse therapy timeline data into sensor values."""
+        if not timeline:
+            data[TANDEM_SENSOR_KEY_LASTSG_MMOL] = UNAVAILABLE
+            data[TANDEM_SENSOR_KEY_LASTSG_MGDL] = UNAVAILABLE
+            data[TANDEM_SENSOR_KEY_LASTSG_TIMESTAMP] = UNAVAILABLE
+            data[TANDEM_SENSOR_KEY_SG_DELTA] = UNAVAILABLE
+            data[TANDEM_SENSOR_KEY_LAST_BOLUS_UNITS] = UNAVAILABLE
+            data[TANDEM_SENSOR_KEY_LAST_BOLUS_TIMESTAMP] = UNAVAILABLE
+            data[TANDEM_SENSOR_KEY_LAST_BOLUS_ATTRS] = {}
+            data[TANDEM_SENSOR_KEY_BASAL_RATE] = UNAVAILABLE
+            data[TANDEM_SENSOR_KEY_ACTIVE_INSULIN] = UNAVAILABLE
+            data[TANDEM_SENSOR_KEY_LAST_MEAL_BOLUS] = UNAVAILABLE
+            data[TANDEM_SENSOR_KEY_LAST_MEAL_BOLUS_ATTRS] = {}
+            data[TANDEM_SENSOR_KEY_CONTROL_IQ_STATUS] = UNAVAILABLE
+            return
+
+        # ── CGM readings ─────────────────────────────────────────────
+        try:
+            cgm_entries = timeline.get("cgm", [])
+            if cgm_entries:
+                # Find the most recent CGM reading
+                latest_reading = None
+                latest_dt = None
+                for entry in cgm_entries:
+                    readings = entry.get("Readings", [])
+                    entry_dt = parse_dotnet_date(entry.get("EventDateTime"))
+                    for reading in readings:
+                        val = reading.get("Value")
+                        rtype = reading.get("Type", "")
+                        if val and val > 0 and rtype == "EGV":
+                            if latest_dt is None or (entry_dt and entry_dt > latest_dt):
+                                latest_reading = val
+                                latest_dt = entry_dt
+
+                if latest_reading is not None:
+                    sg_mgdl = float(latest_reading)
+                    data[TANDEM_SENSOR_KEY_LASTSG_MGDL] = int(sg_mgdl)
+                    data[TANDEM_SENSOR_KEY_LASTSG_MMOL] = round(sg_mgdl * 0.0555, 2)
+
+                    if latest_dt:
+                        data[TANDEM_SENSOR_KEY_LASTSG_TIMESTAMP] = latest_dt.replace(
+                            tzinfo=ZoneInfo(self.timezone)
+                        )
+
+                    # Calculate delta from previous reading
+                    if self._prev_sg_mgdl is not None:
+                        data[TANDEM_SENSOR_KEY_SG_DELTA] = sg_mgdl - self._prev_sg_mgdl
+                    else:
+                        data[TANDEM_SENSOR_KEY_SG_DELTA] = UNAVAILABLE
+                    self._prev_sg_mgdl = sg_mgdl
+                else:
+                    data[TANDEM_SENSOR_KEY_LASTSG_MMOL] = UNAVAILABLE
+                    data[TANDEM_SENSOR_KEY_LASTSG_MGDL] = UNAVAILABLE
+                    data[TANDEM_SENSOR_KEY_LASTSG_TIMESTAMP] = UNAVAILABLE
+                    data[TANDEM_SENSOR_KEY_SG_DELTA] = UNAVAILABLE
+            else:
+                data[TANDEM_SENSOR_KEY_LASTSG_MMOL] = UNAVAILABLE
+                data[TANDEM_SENSOR_KEY_LASTSG_MGDL] = UNAVAILABLE
+                data[TANDEM_SENSOR_KEY_LASTSG_TIMESTAMP] = UNAVAILABLE
+                data[TANDEM_SENSOR_KEY_SG_DELTA] = UNAVAILABLE
+        except Exception as e:
+            _LOGGER.warning("Error parsing CGM data: %s", e)
+            data[TANDEM_SENSOR_KEY_LASTSG_MMOL] = UNAVAILABLE
+            data[TANDEM_SENSOR_KEY_LASTSG_MGDL] = UNAVAILABLE
+            data[TANDEM_SENSOR_KEY_LASTSG_TIMESTAMP] = UNAVAILABLE
+            data[TANDEM_SENSOR_KEY_SG_DELTA] = UNAVAILABLE
+
+        # ── Bolus events ─────────────────────────────────────────────
+        try:
+            bolus_entries = timeline.get("bolus", [])
+            if bolus_entries:
+                # Sort by completion time, most recent first
+                sorted_boluses = sorted(
+                    bolus_entries,
+                    key=lambda b: parse_dotnet_date(
+                        b.get("CompletionDateTime") or b.get("RequestDateTime", 0)
+                    ) or datetime.min,
+                    reverse=True,
+                )
+
+                last_bolus = sorted_boluses[0]
+                insulin = last_bolus.get("InsulinDelivered", 0)
+                data[TANDEM_SENSOR_KEY_LAST_BOLUS_UNITS] = round(float(insulin), 2) if insulin else UNAVAILABLE
+
+                bolus_dt = parse_dotnet_date(
+                    last_bolus.get("CompletionDateTime")
+                    or last_bolus.get("RequestDateTime")
+                )
+                if bolus_dt:
+                    data[TANDEM_SENSOR_KEY_LAST_BOLUS_TIMESTAMP] = bolus_dt.replace(
+                        tzinfo=ZoneInfo(self.timezone)
+                    )
+                else:
+                    data[TANDEM_SENSOR_KEY_LAST_BOLUS_TIMESTAMP] = UNAVAILABLE
+
+                # Extra attributes
+                data[TANDEM_SENSOR_KEY_LAST_BOLUS_ATTRS] = {
+                    "description": last_bolus.get("Description", ""),
+                    "requested_insulin": last_bolus.get("RequestedInsulin"),
+                    "carbs": last_bolus.get("CarbSize"),
+                    "bg": last_bolus.get("BG"),
+                    "iob": last_bolus.get("IOB"),
+                    "completion_status": last_bolus.get("CompletionStatusID", ""),
+                }
+
+                # IOB from the last bolus entry
+                iob = last_bolus.get("IOB")
+                if iob is not None:
+                    data[TANDEM_SENSOR_KEY_ACTIVE_INSULIN] = round(float(iob), 2)
+                else:
+                    data[TANDEM_SENSOR_KEY_ACTIVE_INSULIN] = UNAVAILABLE
+
+                # Find last meal bolus (with carbs)
+                meal_bolus = None
+                for b in sorted_boluses:
+                    carbs = b.get("CarbSize")
+                    if carbs and float(carbs) > 0:
+                        meal_bolus = b
+                        break
+
+                if meal_bolus:
+                    meal_insulin = meal_bolus.get("InsulinDelivered", 0)
+                    data[TANDEM_SENSOR_KEY_LAST_MEAL_BOLUS] = round(float(meal_insulin), 2) if meal_insulin else UNAVAILABLE
+                    data[TANDEM_SENSOR_KEY_LAST_MEAL_BOLUS_ATTRS] = {
+                        "carbs": meal_bolus.get("CarbSize"),
+                        "bg": meal_bolus.get("BG"),
+                        "description": meal_bolus.get("Description", ""),
+                    }
+                else:
+                    data[TANDEM_SENSOR_KEY_LAST_MEAL_BOLUS] = UNAVAILABLE
+                    data[TANDEM_SENSOR_KEY_LAST_MEAL_BOLUS_ATTRS] = {}
+            else:
+                data[TANDEM_SENSOR_KEY_LAST_BOLUS_UNITS] = UNAVAILABLE
+                data[TANDEM_SENSOR_KEY_LAST_BOLUS_TIMESTAMP] = UNAVAILABLE
+                data[TANDEM_SENSOR_KEY_LAST_BOLUS_ATTRS] = {}
+                data[TANDEM_SENSOR_KEY_ACTIVE_INSULIN] = UNAVAILABLE
+                data[TANDEM_SENSOR_KEY_LAST_MEAL_BOLUS] = UNAVAILABLE
+                data[TANDEM_SENSOR_KEY_LAST_MEAL_BOLUS_ATTRS] = {}
+        except Exception as e:
+            _LOGGER.warning("Error parsing bolus data: %s", e)
+            data[TANDEM_SENSOR_KEY_LAST_BOLUS_UNITS] = UNAVAILABLE
+            data[TANDEM_SENSOR_KEY_LAST_BOLUS_TIMESTAMP] = UNAVAILABLE
+            data[TANDEM_SENSOR_KEY_LAST_BOLUS_ATTRS] = {}
+            data[TANDEM_SENSOR_KEY_ACTIVE_INSULIN] = UNAVAILABLE
+            data[TANDEM_SENSOR_KEY_LAST_MEAL_BOLUS] = UNAVAILABLE
+            data[TANDEM_SENSOR_KEY_LAST_MEAL_BOLUS_ATTRS] = {}
+
+        # ── Basal events ─────────────────────────────────────────────
+        try:
+            basal_entries = timeline.get("basal", [])
+            if basal_entries:
+                sorted_basals = sorted(
+                    basal_entries,
+                    key=lambda b: parse_dotnet_date(b.get("EventDateTime", 0)) or datetime.min,
+                    reverse=True,
+                )
+                last_basal = sorted_basals[0]
+                rate = last_basal.get("BasalRate")
+                if rate is not None:
+                    data[TANDEM_SENSOR_KEY_BASAL_RATE] = round(float(rate), 3)
+                else:
+                    data[TANDEM_SENSOR_KEY_BASAL_RATE] = UNAVAILABLE
+
+                # Determine Control-IQ status from basal type
+                basal_type = last_basal.get("Type", "")
+                if basal_type:
+                    data[TANDEM_SENSOR_KEY_CONTROL_IQ_STATUS] = basal_type
+                else:
+                    data[TANDEM_SENSOR_KEY_CONTROL_IQ_STATUS] = UNAVAILABLE
+            else:
+                data[TANDEM_SENSOR_KEY_BASAL_RATE] = UNAVAILABLE
+                data[TANDEM_SENSOR_KEY_CONTROL_IQ_STATUS] = UNAVAILABLE
+        except Exception as e:
+            _LOGGER.warning("Error parsing basal data: %s", e)
+            data[TANDEM_SENSOR_KEY_BASAL_RATE] = UNAVAILABLE
+            data[TANDEM_SENSOR_KEY_CONTROL_IQ_STATUS] = UNAVAILABLE
+
+    def _parse_dashboard_summary(self, summary: dict | None, data: dict) -> None:
+        """Parse dashboard summary into sensor values."""
+        if not summary:
+            data[TANDEM_SENSOR_KEY_AVG_GLUCOSE_MMOL] = UNAVAILABLE
+            data[TANDEM_SENSOR_KEY_AVG_GLUCOSE_MGDL] = UNAVAILABLE
+            data[TANDEM_TIME_IN_RANGE] = UNAVAILABLE
+            data[TANDEM_SENSOR_KEY_CGM_USAGE] = UNAVAILABLE
+            return
+
+        try:
+            avg_reading = summary.get("averageReading")
+            if avg_reading is not None:
+                data[TANDEM_SENSOR_KEY_AVG_GLUCOSE_MGDL] = int(avg_reading)
+                data[TANDEM_SENSOR_KEY_AVG_GLUCOSE_MMOL] = round(
+                    float(avg_reading) * 0.0555, 2
+                )
+            else:
+                data[TANDEM_SENSOR_KEY_AVG_GLUCOSE_MMOL] = UNAVAILABLE
+                data[TANDEM_SENSOR_KEY_AVG_GLUCOSE_MGDL] = UNAVAILABLE
+
+            # Time in range - calculate from CGM data percentages
+            tir = summary.get("timeInRangePercent")
+            if tir is not None:
+                data[TANDEM_TIME_IN_RANGE] = round(float(tir), 1)
+            else:
+                data[TANDEM_TIME_IN_RANGE] = UNAVAILABLE
+
+            # CGM usage
+            cgm_inactive = summary.get("cgmInactivePercent")
+            if cgm_inactive is not None:
+                data[TANDEM_SENSOR_KEY_CGM_USAGE] = round(100.0 - float(cgm_inactive), 1)
+            else:
+                time_in_use = summary.get("timeInUsePercent")
+                if time_in_use is not None:
+                    data[TANDEM_SENSOR_KEY_CGM_USAGE] = round(float(time_in_use), 1)
+                else:
+                    data[TANDEM_SENSOR_KEY_CGM_USAGE] = UNAVAILABLE
+
+        except Exception as e:
+            _LOGGER.warning("Error parsing dashboard summary: %s", e)
+            data[TANDEM_SENSOR_KEY_AVG_GLUCOSE_MMOL] = UNAVAILABLE
+            data[TANDEM_SENSOR_KEY_AVG_GLUCOSE_MGDL] = UNAVAILABLE
+            data[TANDEM_TIME_IN_RANGE] = UNAVAILABLE
+            data[TANDEM_SENSOR_KEY_CGM_USAGE] = UNAVAILABLE
+
+
+# ═══════════════════════════════════════════════════════════════════════════
+# Helper functions (Carelink)
+# ═══════════════════════════════════════════════════════════════════════════
 
 def get_sg(sgs: list, pos: int) -> dict:
     """Retrieve previous sg from list"""

--- a/custom_components/carelink/binary_sensor.py
+++ b/custom_components/carelink/binary_sensor.py
@@ -16,8 +16,13 @@ from .const import (
     DEVICE_PUMP_MODEL,
     DEVICE_PUMP_NAME,
     DEVICE_PUMP_SERIAL,
+    DEVICE_PUMP_MANUFACTURER,
     DOMAIN,
     BINARY_SENSORS,
+    TANDEM_BINARY_SENSORS,
+    PLATFORM_TYPE,
+    PLATFORM_CARELINK,
+    PLATFORM_TANDEM,
 )
 
 
@@ -29,10 +34,14 @@ async def async_setup_entry(
     """Set up carelink sensor platform."""
 
     coordinator = hass.data[DOMAIN][entry.entry_id][COORDINATOR]
+    platform_type = hass.data[DOMAIN][entry.entry_id].get(PLATFORM_TYPE, PLATFORM_CARELINK)
+
+    # Choose the right binary sensor definitions based on platform
+    sensor_definitions = TANDEM_BINARY_SENSORS if platform_type == PLATFORM_TANDEM else BINARY_SENSORS
 
     entities = []
 
-    for sensor_description in BINARY_SENSORS:
+    for sensor_description in sensor_definitions:
 
         entity_name = f"{DOMAIN} {sensor_description.name}"
 
@@ -46,7 +55,7 @@ async def async_setup_entry(
 
 
 class CarelinkConnectivityEntity(CoordinatorEntity, BinarySensorEntity):
-    """Carelink Sensor."""
+    """Carelink / Tandem Binary Sensor."""
 
     def __init__(
         self,
@@ -79,13 +88,16 @@ class CarelinkConnectivityEntity(CoordinatorEntity, BinarySensorEntity):
     @property
     def device_info(self) -> DeviceInfo:
         """Return the device info."""
+        manufacturer = self.coordinator.data.get(
+            DEVICE_PUMP_MANUFACTURER, "Medtronic"
+        )
         return DeviceInfo(
             identifiers={
                 # Serial numbers are unique identifiers within a specific domain
                 (DOMAIN, self.coordinator.data[DEVICE_PUMP_SERIAL])
             },
             name=self.coordinator.data[DEVICE_PUMP_NAME],
-            manufacturer="Medtronic",
+            manufacturer=manufacturer,
             model=self.coordinator.data[DEVICE_PUMP_MODEL],
         )
 

--- a/custom_components/carelink/config_flow.py
+++ b/custom_components/carelink/config_flow.py
@@ -13,17 +13,21 @@ from homeassistant.data_entry_flow import FlowResult
 from homeassistant.exceptions import HomeAssistantError
 
 from .api import CarelinkClient
+from .tandem_api import TandemSourceClient, TandemAuthError
 from .nightscout_uploader import NightscoutUploader
-from .const import DOMAIN, SCAN_INTERVAL
+from .const import (
+    DOMAIN,
+    SCAN_INTERVAL,
+    PLATFORM_TYPE,
+    PLATFORM_CARELINK,
+    PLATFORM_TANDEM,
+)
 
 _LOGGER = logging.getLogger(__name__)
 
 
-async def validate_input(hass: HomeAssistant, data: dict[str, Any]) -> dict[str, Any]:
-    """Validate the user input allows us to connect.
-
-    Data has the keys from the schema with values provided by the user.
-    """
+async def validate_carelink_input(hass: HomeAssistant, data: dict[str, Any]) -> dict[str, Any]:
+    """Validate Carelink (Medtronic) user input."""
     client = CarelinkClient(
         data.setdefault("cl_refresh_token", None),
         data.setdefault("cl_token", None),
@@ -43,6 +47,40 @@ async def validate_input(hass: HomeAssistant, data: dict[str, Any]) -> dict[str,
         except Exception:
             _LOGGER.warning("Failed to close Carelink client during validation")
 
+    await _validate_nightscout(hass, data)
+
+    return {"title": "Carelink"}
+
+
+async def validate_tandem_input(hass: HomeAssistant, data: dict[str, Any]) -> dict[str, Any]:
+    """Validate Tandem Source user input."""
+    email = data.get("tandem_email", "").strip()
+    password = data.get("tandem_password", "")
+    region = data.get("tandem_region", "EU")
+
+    if not email or not password:
+        raise InvalidAuth
+
+    client = TandemSourceClient(email, password, region)
+    try:
+        if not await client.login():
+            raise InvalidAuth
+    except TandemAuthError as e:
+        _LOGGER.warning("Tandem login failed: %s", e)
+        raise InvalidAuth from e
+    finally:
+        try:
+            await client.close()
+        except Exception:
+            _LOGGER.warning("Failed to close Tandem client during validation")
+
+    await _validate_nightscout(hass, data)
+
+    return {"title": f"Tandem t:slim ({region})"}
+
+
+async def _validate_nightscout(hass: HomeAssistant, data: dict[str, Any]) -> None:
+    """Validate Nightscout configuration if provided."""
     nightscout_url = data.setdefault("nightscout_url", None)
     nightscout_api = data.setdefault("nightscout_api", None)
 
@@ -61,9 +99,7 @@ async def validate_input(hass: HomeAssistant, data: dict[str, Any]) -> dict[str,
         if parsed.scheme not in ("http", "https") or not parsed.netloc:
             raise CannotConnect
 
-        uploader = NightscoutUploader(
-            nightscout_url, nightscout_api
-        )
+        uploader = NightscoutUploader(nightscout_url, nightscout_api)
         try:
             if not await uploader.reachServer():
                 raise CannotConnect
@@ -73,22 +109,49 @@ async def validate_input(hass: HomeAssistant, data: dict[str, Any]) -> dict[str,
             except Exception:
                 _LOGGER.warning("Failed to close Nightscout uploader during validation")
 
-    return {"title": "Carelink"}
-
 
 class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
     """Handle a config flow for carelink."""
 
     VERSION = 1
 
-    def _get_schema(self, defaults: dict[str, Any] | None = None, include_auth: bool = True) -> vol.Schema:
-        """Generate the schema with optional default values."""
+    def __init__(self):
+        """Initialize the config flow."""
+        self._platform_type: str | None = None
+
+    # ── Step 1: Choose platform ──────────────────────────────────────────
+
+    async def async_step_user(
+        self, user_input: dict[str, Any] | None = None
+    ) -> FlowResult:
+        """Handle platform selection step."""
+        if user_input is not None:
+            self._platform_type = user_input.get(PLATFORM_TYPE, PLATFORM_CARELINK)
+            if self._platform_type == PLATFORM_TANDEM:
+                return await self.async_step_tandem()
+            return await self.async_step_carelink()
+
+        return self.async_show_form(
+            step_id="user",
+            data_schema=vol.Schema({
+                vol.Required(
+                    PLATFORM_TYPE, default=PLATFORM_CARELINK
+                ): vol.In({
+                    PLATFORM_CARELINK: "Medtronic CareLink",
+                    PLATFORM_TANDEM: "Tandem t:slim (Source)",
+                }),
+            }),
+        )
+
+    # ── Step 2a: Carelink configuration ──────────────────────────────────
+
+    def _get_carelink_schema(self, defaults: dict[str, Any] | None = None, include_auth: bool = True) -> vol.Schema:
+        """Generate the Carelink schema with optional default values."""
         if defaults is None:
             defaults = {}
 
         schema = {}
 
-        # Only include auth fields if requested (e.g. initial setup)
         if include_auth:
             schema.update({
                 vol.Optional("cl_token", description={"suggested_value": defaults.get("cl_token", "")}): str,
@@ -99,7 +162,6 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
                 vol.Optional("patientId", description={"suggested_value": defaults.get("patientId", "")}): str,
             })
 
-        # Always include Nightscout and Scan Interval configuration
         schema.update({
             vol.Optional("nightscout_url", description={"suggested_value": defaults.get("nightscout_url", "")}): str,
             vol.Optional("nightscout_api", description={"suggested_value": defaults.get("nightscout_api", "")}): str,
@@ -108,15 +170,16 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
 
         return vol.Schema(schema)
 
-    async def async_step_user(
+    async def async_step_carelink(
         self, user_input: dict[str, Any] | None = None
     ) -> FlowResult:
-        """Handle the initial step."""
+        """Handle Carelink configuration step."""
         errors = {}
 
         if user_input is not None:
+            user_input[PLATFORM_TYPE] = PLATFORM_CARELINK
             try:
-                info = await validate_input(self.hass, user_input)
+                info = await validate_carelink_input(self.hass, user_input)
             except CannotConnect:
                 errors["base"] = "cannot_connect"
             except InvalidAuth:
@@ -127,12 +190,66 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
             else:
                 return self.async_create_entry(title=info["title"], data=user_input)
 
-        # Show full form (Auth + Nightscout)
         return self.async_show_form(
-            step_id="user",
-            data_schema=self._get_schema(user_input, include_auth=True),
+            step_id="carelink",
+            data_schema=self._get_carelink_schema(user_input, include_auth=True),
             errors=errors
         )
+
+    # ── Step 2b: Tandem configuration ────────────────────────────────────
+
+    def _get_tandem_schema(self, defaults: dict[str, Any] | None = None, include_auth: bool = True) -> vol.Schema:
+        """Generate the Tandem schema with optional default values."""
+        if defaults is None:
+            defaults = {}
+
+        schema = {}
+
+        if include_auth:
+            schema.update({
+                vol.Required("tandem_email", description={"suggested_value": defaults.get("tandem_email", "")}): str,
+                vol.Required("tandem_password", description={"suggested_value": defaults.get("tandem_password", "")}): str,
+                vol.Required("tandem_region", default=defaults.get("tandem_region", "EU")): vol.In({
+                    "EU": "Europe",
+                    "US": "United States",
+                }),
+            })
+
+        schema.update({
+            vol.Optional("nightscout_url", description={"suggested_value": defaults.get("nightscout_url", "")}): str,
+            vol.Optional("nightscout_api", description={"suggested_value": defaults.get("nightscout_api", "")}): str,
+            vol.Required(SCAN_INTERVAL, description={"suggested_value": defaults.get(SCAN_INTERVAL, 300)}): vol.All(vol.Coerce(int), vol.Range(min=60, max=900))
+        })
+
+        return vol.Schema(schema)
+
+    async def async_step_tandem(
+        self, user_input: dict[str, Any] | None = None
+    ) -> FlowResult:
+        """Handle Tandem Source configuration step."""
+        errors = {}
+
+        if user_input is not None:
+            user_input[PLATFORM_TYPE] = PLATFORM_TANDEM
+            try:
+                info = await validate_tandem_input(self.hass, user_input)
+            except CannotConnect:
+                errors["base"] = "cannot_connect"
+            except InvalidAuth:
+                errors["base"] = "invalid_auth"
+            except Exception:  # pylint: disable=broad-except
+                _LOGGER.exception("Unexpected exception")
+                errors["base"] = "unknown"
+            else:
+                return self.async_create_entry(title=info["title"], data=user_input)
+
+        return self.async_show_form(
+            step_id="tandem",
+            data_schema=self._get_tandem_schema(user_input, include_auth=True),
+            errors=errors
+        )
+
+    # ── Reconfiguration ──────────────────────────────────────────────────
 
     async def async_step_reconfigure(
         self, user_input: dict[str, Any] | None = None
@@ -140,16 +257,17 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
         """Handle reconfiguration of the integration."""
         errors = {}
 
-        # Get the current configuration entry
         entry = self.hass.config_entries.async_get_entry(self.context["entry_id"])
+        platform = entry.data.get(PLATFORM_TYPE, PLATFORM_CARELINK)
 
         if user_input is not None:
-            # Merge existing auth data (hidden from form) with new Nightscout input
-            # This ensures validation passes using the credentials we already have
             full_config = {**entry.data, **user_input}
 
             try:
-                await validate_input(self.hass, full_config)
+                if platform == PLATFORM_TANDEM:
+                    await validate_tandem_input(self.hass, full_config)
+                else:
+                    await validate_carelink_input(self.hass, full_config)
             except CannotConnect:
                 errors["base"] = "cannot_connect"
             except InvalidAuth:
@@ -162,13 +280,16 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
                     entry, data=full_config
                 )
 
-        # Prepare defaults: use user_input if a retry is happening, otherwise use stored entry data
         schema_defaults = user_input if user_input else dict(entry.data)
 
-        # Show partial form (Nightscout Only + Scan Interval)
+        if platform == PLATFORM_TANDEM:
+            schema = self._get_tandem_schema(schema_defaults, include_auth=False)
+        else:
+            schema = self._get_carelink_schema(schema_defaults, include_auth=False)
+
         return self.async_show_form(
             step_id="reconfigure",
-            data_schema=self._get_schema(schema_defaults, include_auth=False),
+            data_schema=schema,
             errors=errors,
         )
 

--- a/custom_components/carelink/const.py
+++ b/custom_components/carelink/const.py
@@ -16,9 +16,15 @@ UNAVAILABLE = None
 
 DOMAIN = "carelink"
 CLIENT = "carelink_client"
+TANDEM_CLIENT = "tandem_client"
 COORDINATOR = "coordinator"
 UPLOADER = "nightscout_uploader"
 SCAN_INTERVAL = "scan_interval"
+
+# Platform type: "carelink" (Medtronic) or "tandem" (Tandem t:slim)
+PLATFORM_TYPE = "platform_type"
+PLATFORM_CARELINK = "carelink"
+PLATFORM_TANDEM = "tandem"
 
 SENSOR_KEY_LASTSG_MMOL = "last_sg_mmol"
 SENSOR_KEY_LASTSG_MGDL = "last_sg_mgdl"
@@ -84,6 +90,7 @@ BINARY_SENSOR_KEY_CONDUIT_SENSOR_IN_RANGE = "binary_sensor_conduit_sensor_in_ran
 DEVICE_PUMP_SERIAL = "pump serial"
 DEVICE_PUMP_NAME = "pump name"
 DEVICE_PUMP_MODEL = "pump model"
+DEVICE_PUMP_MANUFACTURER = "pump manufacturer"
 
 MMOL = "mmol/L"
 MGDL = "mg/dL"
@@ -475,6 +482,207 @@ BINARY_SENSORS = (
         entity_category=EntityCategory.DIAGNOSTIC,
     ),
 )
+
+# ── Tandem t:slim sensor keys ────────────────────────────────────────────
+
+TANDEM_SENSOR_KEY_LASTSG_MMOL = "tandem_last_sg_mmol"
+TANDEM_SENSOR_KEY_LASTSG_MGDL = "tandem_last_sg_mgdl"
+TANDEM_SENSOR_KEY_LASTSG_TIMESTAMP = "tandem_last_sg_timestamp"
+TANDEM_SENSOR_KEY_SG_DELTA = "tandem_last_sg_delta"
+TANDEM_SENSOR_KEY_LAST_BOLUS_UNITS = "tandem_last_bolus_units"
+TANDEM_SENSOR_KEY_LAST_BOLUS_TIMESTAMP = "tandem_last_bolus_timestamp"
+TANDEM_SENSOR_KEY_LAST_BOLUS_ATTRS = "tandem_last_bolus_attributes"
+TANDEM_SENSOR_KEY_BASAL_RATE = "tandem_basal_rate"
+TANDEM_SENSOR_KEY_ACTIVE_INSULIN = "tandem_active_insulin"
+TANDEM_SENSOR_KEY_LAST_UPLOAD = "tandem_last_upload"
+TANDEM_SENSOR_KEY_SOFTWARE_VERSION = "tandem_software_version"
+TANDEM_SENSOR_KEY_PUMP_SERIAL_INFO = "tandem_pump_serial_info"
+TANDEM_SENSOR_KEY_PUMP_MODEL_INFO = "tandem_pump_model_info"
+TANDEM_SENSOR_KEY_AVG_GLUCOSE_MMOL = "tandem_average_glucose_mmol"
+TANDEM_SENSOR_KEY_AVG_GLUCOSE_MGDL = "tandem_average_glucose_mgdl"
+TANDEM_SENSOR_KEY_TIME_IN_RANGE = "tandem_time_in_range"
+TANDEM_SENSOR_KEY_CGM_USAGE = "tandem_cgm_usage"
+TANDEM_SENSOR_KEY_CONTROL_IQ_STATUS = "tandem_control_iq_status"
+TANDEM_SENSOR_KEY_UPDATE_TIMESTAMP = "tandem_last_update_timestamp"
+TANDEM_SENSOR_KEY_LAST_MEAL_BOLUS = "tandem_last_meal_bolus"
+TANDEM_SENSOR_KEY_LAST_MEAL_BOLUS_ATTRS = "tandem_last_meal_bolus_attributes"
+
+TANDEM_SENSORS = (
+    SensorEntityDescription(
+        key=TANDEM_SENSOR_KEY_LASTSG_MMOL,
+        name="Last glucose level mmol",
+        native_unit_of_measurement=MMOL,
+        state_class=SensorStateClass.MEASUREMENT,
+        device_class=SensorDeviceClass.BLOOD_GLUCOSE_CONCENTRATION,
+        icon="mdi:water",
+        entity_category=None,
+    ),
+    SensorEntityDescription(
+        key=TANDEM_SENSOR_KEY_LASTSG_MGDL,
+        name="Last glucose level mg/dl",
+        native_unit_of_measurement=MGDL,
+        state_class=SensorStateClass.MEASUREMENT,
+        device_class=SensorDeviceClass.BLOOD_GLUCOSE_CONCENTRATION,
+        icon="mdi:water",
+        entity_category=None,
+    ),
+    SensorEntityDescription(
+        key=TANDEM_SENSOR_KEY_LASTSG_TIMESTAMP,
+        name="Last glucose update",
+        native_unit_of_measurement=None,
+        state_class=None,
+        device_class=SensorDeviceClass.TIMESTAMP,
+        icon="mdi:clock",
+        entity_category=None,
+    ),
+    SensorEntityDescription(
+        key=TANDEM_SENSOR_KEY_SG_DELTA,
+        name="Last glucose delta",
+        native_unit_of_measurement=None,
+        state_class=SensorStateClass.MEASUREMENT,
+        device_class=None,
+        icon="mdi:plus-minus-variant",
+        entity_category=None,
+    ),
+    SensorEntityDescription(
+        key=TANDEM_SENSOR_KEY_UPDATE_TIMESTAMP,
+        name="Last update",
+        native_unit_of_measurement=None,
+        state_class=None,
+        device_class=SensorDeviceClass.TIMESTAMP,
+        icon="mdi:clock",
+        entity_category=None,
+    ),
+    SensorEntityDescription(
+        key=TANDEM_SENSOR_KEY_ACTIVE_INSULIN,
+        name="Active insulin (IOB)",
+        native_unit_of_measurement=UNITS,
+        state_class=SensorStateClass.MEASUREMENT,
+        device_class=None,
+        icon="mdi:water-alert",
+        entity_category=None,
+    ),
+    SensorEntityDescription(
+        key=TANDEM_SENSOR_KEY_BASAL_RATE,
+        name="Basal rate",
+        native_unit_of_measurement="U/hr",
+        state_class=SensorStateClass.MEASUREMENT,
+        device_class=None,
+        icon="mdi:chart-line",
+        entity_category=None,
+    ),
+    SensorEntityDescription(
+        key=TANDEM_SENSOR_KEY_LAST_BOLUS_UNITS,
+        name="Last bolus",
+        native_unit_of_measurement=UNITS,
+        state_class=SensorStateClass.MEASUREMENT,
+        device_class=None,
+        icon="mdi:needle",
+        entity_category=None,
+    ),
+    SensorEntityDescription(
+        key=TANDEM_SENSOR_KEY_LAST_BOLUS_TIMESTAMP,
+        name="Last bolus time",
+        native_unit_of_measurement=None,
+        state_class=None,
+        device_class=SensorDeviceClass.TIMESTAMP,
+        icon="mdi:clock",
+        entity_category=None,
+    ),
+    SensorEntityDescription(
+        key=TANDEM_SENSOR_KEY_LAST_MEAL_BOLUS,
+        name="Last meal bolus",
+        native_unit_of_measurement=UNITS,
+        state_class=SensorStateClass.MEASUREMENT,
+        device_class=None,
+        icon="mdi:food",
+        entity_category=None,
+    ),
+    SensorEntityDescription(
+        key=TANDEM_SENSOR_KEY_LAST_UPLOAD,
+        name="Last pump upload",
+        native_unit_of_measurement=None,
+        state_class=None,
+        device_class=SensorDeviceClass.TIMESTAMP,
+        icon="mdi:cloud-upload",
+        entity_category=None,
+    ),
+    SensorEntityDescription(
+        key=TANDEM_SENSOR_KEY_AVG_GLUCOSE_MMOL,
+        name="Average glucose level mmol",
+        native_unit_of_measurement=MMOL,
+        state_class=SensorStateClass.MEASUREMENT,
+        device_class=SensorDeviceClass.BLOOD_GLUCOSE_CONCENTRATION,
+        icon="mdi:chart-line",
+        entity_category=None,
+    ),
+    SensorEntityDescription(
+        key=TANDEM_SENSOR_KEY_AVG_GLUCOSE_MGDL,
+        name="Average glucose level mg/dl",
+        native_unit_of_measurement=MGDL,
+        state_class=SensorStateClass.MEASUREMENT,
+        device_class=SensorDeviceClass.BLOOD_GLUCOSE_CONCENTRATION,
+        icon="mdi:chart-line",
+        entity_category=None,
+    ),
+    SensorEntityDescription(
+        key=TANDEM_SENSOR_KEY_TIME_IN_RANGE,
+        name="Time in range",
+        native_unit_of_measurement=PERCENT,
+        state_class=SensorStateClass.MEASUREMENT,
+        device_class=None,
+        icon=None,
+        entity_category=None,
+    ),
+    SensorEntityDescription(
+        key=TANDEM_SENSOR_KEY_CGM_USAGE,
+        name="CGM usage",
+        native_unit_of_measurement=PERCENT,
+        state_class=SensorStateClass.MEASUREMENT,
+        device_class=None,
+        icon="mdi:percent",
+        entity_category=None,
+    ),
+    SensorEntityDescription(
+        key=TANDEM_SENSOR_KEY_CONTROL_IQ_STATUS,
+        name="Control-IQ status",
+        native_unit_of_measurement=None,
+        state_class=None,
+        device_class=None,
+        icon="mdi:robot",
+        entity_category=None,
+    ),
+    SensorEntityDescription(
+        key=TANDEM_SENSOR_KEY_SOFTWARE_VERSION,
+        name="Software version",
+        device_class=None,
+        native_unit_of_measurement=None,
+        state_class=None,
+        icon="mdi:code-tags",
+        entity_category=EntityCategory.DIAGNOSTIC,
+    ),
+    SensorEntityDescription(
+        key=TANDEM_SENSOR_KEY_PUMP_SERIAL_INFO,
+        name="Pump serial number",
+        device_class=None,
+        native_unit_of_measurement=None,
+        state_class=None,
+        icon="mdi:identifier",
+        entity_category=EntityCategory.DIAGNOSTIC,
+    ),
+    SensorEntityDescription(
+        key=TANDEM_SENSOR_KEY_PUMP_MODEL_INFO,
+        name="Pump model",
+        device_class=None,
+        native_unit_of_measurement=None,
+        state_class=None,
+        icon="mdi:code-tags",
+        entity_category=EntityCategory.DIAGNOSTIC,
+    ),
+)
+
+# Tandem has no binary sensors (no real-time connectivity data available)
+TANDEM_BINARY_SENSORS = ()
 
 CARELINK_CODE_MAP = {
     817 : "BC_SID_SG_APPROACH_HIGH_LIMIT_CHECK_BG",

--- a/custom_components/carelink/manifest.json
+++ b/custom_components/carelink/manifest.json
@@ -9,6 +9,6 @@
   "iot_class": "cloud_polling",
   "issue_tracker": "https://github.com/yo-han/Home-Assistant-Carelink/issues",
   "requirements": ["aiofiles>=0.8.0", "httpx>=0.23.0"],
-  "version": "2023.2.3",
+  "version": "2024.1.0",
   "zeroconf": []
 }

--- a/custom_components/carelink/sensor.py
+++ b/custom_components/carelink/sensor.py
@@ -1,4 +1,4 @@
-"""Support for Carelink."""
+"""Support for Carelink / Tandem sensors."""
 from __future__ import annotations
 
 from homeassistant.components.sensor import (
@@ -20,8 +20,13 @@ from .const import (
     DEVICE_PUMP_MODEL,
     DEVICE_PUMP_NAME,
     DEVICE_PUMP_SERIAL,
+    DEVICE_PUMP_MANUFACTURER,
     DOMAIN,
     SENSORS,
+    TANDEM_SENSORS,
+    PLATFORM_TYPE,
+    PLATFORM_CARELINK,
+    PLATFORM_TANDEM,
 )
 
 
@@ -33,10 +38,14 @@ async def async_setup_entry(
     """Set up carelink sensor platform."""
 
     coordinator = hass.data[DOMAIN][entry.entry_id][COORDINATOR]
+    platform_type = hass.data[DOMAIN][entry.entry_id].get(PLATFORM_TYPE, PLATFORM_CARELINK)
+
+    # Choose the right sensor definitions based on platform
+    sensor_definitions = TANDEM_SENSORS if platform_type == PLATFORM_TANDEM else SENSORS
 
     entities = []
 
-    for sensor_description in SENSORS:
+    for sensor_description in sensor_definitions:
 
         entity_name = f"{DOMAIN} {sensor_description.name}"
 
@@ -49,7 +58,7 @@ async def async_setup_entry(
 
 
 class CarelinkSensorEntity(CoordinatorEntity, SensorEntity):
-    """Carelink Sensor."""
+    """Carelink / Tandem Sensor."""
 
     def __init__(
         self,
@@ -94,13 +103,16 @@ class CarelinkSensorEntity(CoordinatorEntity, SensorEntity):
     @property
     def device_info(self) -> DeviceInfo:
         """Return the device info."""
+        manufacturer = self.coordinator.data.get(
+            DEVICE_PUMP_MANUFACTURER, "Medtronic"
+        )
         return DeviceInfo(
             identifiers={
                 # Serial numbers are unique identifiers within a specific domain
                 (DOMAIN, self.coordinator.data[DEVICE_PUMP_SERIAL])
             },
             name=self.coordinator.data[DEVICE_PUMP_NAME],
-            manufacturer="Medtronic",
+            manufacturer=manufacturer,
             model=self.coordinator.data[DEVICE_PUMP_MODEL],
         )
 

--- a/custom_components/carelink/strings.json
+++ b/custom_components/carelink/strings.json
@@ -1,35 +1,48 @@
 {
   "config": {
-    "flow_title": "Setup your Carelink account",
+    "flow_title": "Setup your diabetes pump",
     "step": {
       "user": {
-        "title": "Setup your Carelink account",
-        "description": "Provide your session token. Please ensure that you enter the 2-letter ISO code corresponding to the country in which your account was registered. If you are logging in with a Carelink Care Partner account, please include the patient ID, which should be the username of the main Carelink account.",
+        "title": "Choose your pump platform",
+        "description": "Select the diabetes pump platform you want to connect.",
         "data": {
-          "scan_interval": "[%key:common::config_flow::data::scan_interval%]",
-          "cl_token": "[%key:common::config_flow::data::cl_token%]",
-          "cl_refresh_token": "[%key:common::config_flow::data::cl_refresh_token%]",
-          "cl_client_id": "[%key:common::config_flow::data::cl_client_id%]",
-          "cl_client_secret": "[%key:common::config_flow::data::cl_client_secret%]",
-          "cl_mag_identifier": "[%key:common::config_flow::data::cl_mag_identifier%]",
-          "patientId": "[%key:common::config_flow::data::patientId%]",
-          "nightscout_url": "[%key:common::config_flow::data::nightscout_url%]",
-          "nightscout_api": "[%key:common::config_flow::data::nightscout_api%]"
+          "platform_type": "Pump platform"
         }
       },
-	  "reconfigure": {
+      "carelink": {
         "title": "Setup your Carelink account",
         "description": "Provide your session token. Please ensure that you enter the 2-letter ISO code corresponding to the country in which your account was registered. If you are logging in with a Carelink Care Partner account, please include the patient ID, which should be the username of the main Carelink account.",
         "data": {
-          "scan_interval": "[%key:common::config_flow::data::scan_interval%]",
-          "cl_token": "[%key:common::config_flow::data::cl_token%]",
-          "cl_refresh_token": "[%key:common::config_flow::data::cl_refresh_token%]",
-          "cl_client_id": "[%key:common::config_flow::data::cl_client_id%]",
-          "cl_client_secret": "[%key:common::config_flow::data::cl_client_secret%]",
-          "cl_mag_identifier": "[%key:common::config_flow::data::cl_mag_identifier%]",
-          "patientId": "[%key:common::config_flow::data::patientId%]",
-          "nightscout_url": "[%key:common::config_flow::data::nightscout_url%]",
-          "nightscout_api": "[%key:common::config_flow::data::nightscout_api%]"
+          "scan_interval": "Scan interval (seconds)",
+          "cl_token": "Access token",
+          "cl_refresh_token": "Refresh token",
+          "cl_client_id": "Client ID",
+          "cl_client_secret": "Client secret",
+          "cl_mag_identifier": "MAG identifier",
+          "patientId": "Patient ID",
+          "nightscout_url": "Nightscout URL",
+          "nightscout_api": "Nightscout API secret"
+        }
+      },
+      "tandem": {
+        "title": "Setup your Tandem Source account",
+        "description": "Enter your Tandem Diabetes Source account credentials. This connects to source.tandemdiabetes.com (US) or source.eu.tandemdiabetes.com (EU) to fetch data from your Tandem t:slim pump.",
+        "data": {
+          "tandem_email": "Email address",
+          "tandem_password": "Password",
+          "tandem_region": "Region",
+          "scan_interval": "Scan interval (seconds)",
+          "nightscout_url": "Nightscout URL",
+          "nightscout_api": "Nightscout API secret"
+        }
+      },
+      "reconfigure": {
+        "title": "Reconfigure integration",
+        "description": "Update your integration settings. Authentication credentials are preserved from the original setup.",
+        "data": {
+          "scan_interval": "Scan interval (seconds)",
+          "nightscout_url": "Nightscout URL",
+          "nightscout_api": "Nightscout API secret"
         }
       }
     },

--- a/custom_components/carelink/tandem_api.py
+++ b/custom_components/carelink/tandem_api.py
@@ -1,0 +1,465 @@
+"""Tandem Diabetes Source API client.
+
+Implements OIDC/PKCE authentication against source.tandemdiabetes.com (US)
+and source.eu.tandemdiabetes.com (EU) to fetch pump data for Tandem t:slim
+insulin pumps.
+
+Authentication flow:
+1. POST credentials to login API
+2. GET authorization endpoint with PKCE challenge (follows redirects to get code)
+3. POST code + verifier to token endpoint (gets access_token + id_token)
+4. Decode JWT id_token to extract pumperId and accountId
+
+Data sources:
+- Tandem Source API: pump metadata (serial, model, last upload)
+- ControlIQ API: therapy timeline (CGM, bolus, basal) and summary statistics
+"""
+from __future__ import annotations
+
+import base64
+import hashlib
+import json
+import logging
+import os
+import re
+import time
+from datetime import datetime, timedelta
+from urllib.parse import urlencode, urlparse, parse_qs
+
+import httpx
+
+_LOGGER = logging.getLogger(__name__)
+
+USER_AGENT = (
+    "Mozilla/5.0 (Linux; Android 13) AppleWebKit/537.36 "
+    "(KHTML, like Gecko) Chrome/120.0.0.0 Mobile Safari/537.36"
+)
+
+
+class TandemAuthError(Exception):
+    """Raised when authentication fails."""
+
+
+class TandemApiError(Exception):
+    """Raised when an API call fails."""
+
+
+class TandemSourceClient:
+    """Async API client for Tandem Diabetes Source platform."""
+
+    LOGIN_PAGE_URL = "https://sso.tandemdiabetes.com/"
+
+    _REGION_URLS = {
+        "EU": {
+            "LOGIN_API": "https://tdcservices.eu.tandemdiabetes.com/accounts/api/login",
+            "AUTHORIZE": "https://tdcservices.eu.tandemdiabetes.com/accounts/api/connect/authorize",
+            "TOKEN": "https://tdcservices.eu.tandemdiabetes.com/accounts/api/connect/token",
+            "JWKS": "https://tdcservices.eu.tandemdiabetes.com/accounts/api/.well-known/openid-configuration/jwks",
+            "ISSUER": "https://tdcservices.eu.tandemdiabetes.com/accounts/api",
+            "CLIENT_ID": "1519e414-eeec-492e-8c5e-97bea4815a10",
+            "SOURCE_URL": "https://source.eu.tandemdiabetes.com/",
+            "REDIRECT_URI": "https://source.eu.tandemdiabetes.com/authorize/callback",
+            "TDC_BASE": "https://tdcservices.eu.tandemdiabetes.com/",
+        },
+        "US": {
+            "LOGIN_API": "https://tdcservices.tandemdiabetes.com/accounts/api/login",
+            "AUTHORIZE": "https://tdcservices.tandemdiabetes.com/accounts/api/connect/authorize",
+            "TOKEN": "https://tdcservices.tandemdiabetes.com/accounts/api/connect/token",
+            "JWKS": "https://tdcservices.tandemdiabetes.com/accounts/api/.well-known/openid-configuration/jwks",
+            "ISSUER": "https://tdcservices.tandemdiabetes.com/accounts/api",
+            "CLIENT_ID": "0oa27ho9tpZE9Arjy4h7",
+            "SOURCE_URL": "https://source.tandemdiabetes.com/",
+            "REDIRECT_URI": "https://sso.tandemdiabetes.com/auth/callback",
+            "TDC_BASE": "https://tdcservices.tandemdiabetes.com/",
+        },
+    }
+
+    def __init__(self, email: str, password: str, region: str = "EU"):
+        self.email = email
+        self.password = password
+        self.region = region.upper()
+        if self.region not in self._REGION_URLS:
+            raise ValueError(f"Invalid region '{region}'. Must be 'US' or 'EU'.")
+        self.urls = self._REGION_URLS[self.region]
+
+        self.access_token: str | None = None
+        self.id_token: str | None = None
+        self.pumper_id: str | None = None
+        self.account_id: str | None = None
+        self.token_expires_at: float = 0
+
+        self._client: httpx.AsyncClient | None = None
+
+    def _get_client(self) -> httpx.AsyncClient:
+        """Get or create the async HTTP client."""
+        if self._client is None or self._client.is_closed:
+            self._client = httpx.AsyncClient(
+                follow_redirects=True,
+                timeout=30.0,
+                headers={"User-Agent": USER_AGENT},
+            )
+        return self._client
+
+    @staticmethod
+    def _generate_code_verifier() -> str:
+        """Generate a high-entropy PKCE code verifier."""
+        return base64.urlsafe_b64encode(os.urandom(64)).decode("utf-8").rstrip("=")
+
+    @staticmethod
+    def _generate_code_challenge(verifier: str) -> str:
+        """Generate S256 code challenge from verifier."""
+        digest = hashlib.sha256(verifier.encode("utf-8")).digest()
+        return base64.urlsafe_b64encode(digest).decode("utf-8").rstrip("=")
+
+    def _needs_login(self) -> bool:
+        """Check if we need to (re)authenticate."""
+        if not self.access_token:
+            return True
+        # Re-login 5 minutes before expiry
+        return time.time() >= (self.token_expires_at - 300)
+
+    async def login(self) -> bool:
+        """Perform OIDC/PKCE authentication.
+
+        Returns True on success, raises TandemAuthError on failure.
+        """
+        if not self._needs_login():
+            return True
+
+        client = self._get_client()
+
+        _LOGGER.debug("Tandem: Starting OIDC login for %s region", self.region)
+
+        # Step 1: Initialize session (establish cookies)
+        try:
+            await client.get(self.LOGIN_PAGE_URL)
+        except httpx.HTTPError as e:
+            raise TandemAuthError(f"Cannot reach login page: {e}") from e
+
+        # Step 2: POST credentials to login API
+        try:
+            login_resp = await client.post(
+                self.urls["LOGIN_API"],
+                json={"username": self.email, "password": self.password},
+                headers={"Referer": self.LOGIN_PAGE_URL},
+            )
+        except httpx.HTTPError as e:
+            raise TandemAuthError(f"Login request failed: {e}") from e
+
+        if login_resp.status_code != 200:
+            raise TandemAuthError(
+                f"Login failed with HTTP {login_resp.status_code}: {login_resp.text[:200]}"
+            )
+
+        login_json = login_resp.json()
+        if login_json.get("status") != "SUCCESS":
+            raise TandemAuthError(
+                f"Login rejected: {login_json.get('message', 'Unknown error')}"
+            )
+
+        _LOGGER.debug("Tandem: Login credentials accepted")
+
+        # Step 3: OIDC authorize with PKCE
+        code_verifier = self._generate_code_verifier()
+        code_challenge = self._generate_code_challenge(code_verifier)
+
+        auth_params = {
+            "client_id": self.urls["CLIENT_ID"],
+            "response_type": "code",
+            "scope": "openid profile email",
+            "redirect_uri": self.urls["REDIRECT_URI"],
+            "code_challenge": code_challenge,
+            "code_challenge_method": "S256",
+        }
+
+        try:
+            auth_resp = await client.get(
+                self.urls["AUTHORIZE"] + "?" + urlencode(auth_params),
+                headers={"Referer": self.LOGIN_PAGE_URL},
+            )
+        except httpx.HTTPError as e:
+            raise TandemAuthError(f"Authorization request failed: {e}") from e
+
+        # Extract authorization code from redirect URL
+        final_url = str(auth_resp.url)
+        parsed = urlparse(final_url)
+        query_params = parse_qs(parsed.query)
+
+        if "code" not in query_params:
+            raise TandemAuthError(
+                f"No authorization code in redirect URL: {final_url[:200]}"
+            )
+
+        auth_code = query_params["code"][0]
+        _LOGGER.debug("Tandem: Got authorization code")
+
+        # Step 4: Exchange code for tokens
+        token_data = {
+            "grant_type": "authorization_code",
+            "client_id": self.urls["CLIENT_ID"],
+            "code": auth_code,
+            "redirect_uri": self.urls["REDIRECT_URI"],
+            "code_verifier": code_verifier,
+        }
+
+        try:
+            token_resp = await client.post(
+                self.urls["TOKEN"],
+                data=token_data,
+                headers={"Content-Type": "application/x-www-form-urlencoded"},
+            )
+        except httpx.HTTPError as e:
+            raise TandemAuthError(f"Token exchange failed: {e}") from e
+
+        if token_resp.status_code // 100 != 2:
+            raise TandemAuthError(
+                f"Token exchange HTTP {token_resp.status_code}: {token_resp.text[:200]}"
+            )
+
+        token_json = token_resp.json()
+
+        if "access_token" not in token_json:
+            raise TandemAuthError("Missing access_token in token response")
+        if "id_token" not in token_json:
+            raise TandemAuthError("Missing id_token in token response")
+
+        self.access_token = token_json["access_token"]
+        self.id_token = token_json["id_token"]
+        self.token_expires_at = time.time() + token_json.get("expires_in", 3600)
+
+        # Step 5: Decode JWT to get pumperId and accountId
+        self._extract_jwt_claims()
+
+        _LOGGER.info(
+            "Tandem: Login successful (pumperId=%s, region=%s)",
+            self.pumper_id,
+            self.region,
+        )
+        return True
+
+    def _extract_jwt_claims(self):
+        """Extract claims from the id_token JWT payload.
+
+        We skip cryptographic verification since we received the token over
+        HTTPS directly from the token endpoint.
+        """
+        parts = self.id_token.split(".")
+        if len(parts) != 3:
+            raise TandemAuthError("Invalid JWT format")
+
+        # Base64url decode the payload (middle part)
+        payload = parts[1]
+        # Add padding
+        payload += "=" * (4 - len(payload) % 4)
+
+        try:
+            claims = json.loads(base64.urlsafe_b64decode(payload))
+        except (json.JSONDecodeError, Exception) as e:
+            raise TandemAuthError(f"Cannot decode JWT payload: {e}") from e
+
+        self.pumper_id = claims.get("pumperId")
+        self.account_id = claims.get("accountId")
+
+        if not self.pumper_id:
+            raise TandemAuthError("No pumperId found in JWT claims")
+
+        _LOGGER.debug(
+            "Tandem: JWT decoded - pumperId=%s, accountId=%s",
+            self.pumper_id,
+            self.account_id,
+        )
+
+    def _api_headers(self) -> dict:
+        """Get headers for authenticated API requests."""
+        return {
+            "Authorization": f"Bearer {self.access_token}",
+            "User-Agent": USER_AGENT,
+        }
+
+    async def _api_get(self, url: str) -> dict:
+        """Make an authenticated GET request with automatic re-login on 401."""
+        client = self._get_client()
+
+        resp = await client.get(url, headers=self._api_headers())
+
+        if resp.status_code == 401:
+            _LOGGER.info("Tandem: Got 401, attempting re-login")
+            self.access_token = None
+            await self.login()
+            resp = await client.get(url, headers=self._api_headers())
+
+        if resp.status_code != 200:
+            raise TandemApiError(
+                f"API GET {url} failed ({resp.status_code}): {resp.text[:300]}"
+            )
+
+        return resp.json()
+
+    # ── Tandem Source API endpoints ──────────────────────────────────────
+
+    async def get_pumper_info(self) -> dict:
+        """Get user and pump information."""
+        return await self._api_get(
+            f"{self.urls['SOURCE_URL']}api/pumpers/pumpers/{self.pumper_id}"
+        )
+
+    async def get_pump_event_metadata(self) -> list:
+        """Get pump event metadata (serial, model, last upload, etc.).
+
+        Returns a list of dicts, one per pump on the account. Each dict has:
+        tconnectDeviceId, serialNumber, modelNumber, minDateWithEvents,
+        maxDateWithEvents, lastUpload, patientName, patientDateOfBirth,
+        patientCareGiver, softwareVersion, partNumber
+        """
+        return await self._api_get(
+            f"{self.urls['SOURCE_URL']}api/reports/reportsfacade/"
+            f"{self.pumper_id}/pumpeventmetadata"
+        )
+
+    # ── ControlIQ API endpoints ──────────────────────────────────────────
+    # These use the TDC services base URL and may or may not accept the
+    # Tandem Source OIDC access token. Failures are handled gracefully.
+
+    async def get_therapy_timeline(
+        self, start_date: str, end_date: str
+    ) -> dict | None:
+        """Fetch therapy timeline data (basal, bolus, CGM readings).
+
+        Args:
+            start_date: Date in MM-DD-YYYY format
+            end_date: Date in MM-DD-YYYY format
+
+        Returns dict with 'basal', 'bolus', 'cgm' keys, or None if unavailable.
+        """
+        try:
+            user_guid = self.account_id or self.pumper_id
+            url = (
+                f"{self.urls['TDC_BASE']}tconnect/controliq/api/therapytimeline/"
+                f"users/{user_guid}?startDate={start_date}&endDate={end_date}"
+            )
+            return await self._api_get(url)
+        except (TandemApiError, httpx.HTTPError) as e:
+            _LOGGER.debug("Therapy timeline not available: %s", e)
+            return None
+
+    async def get_dashboard_summary(
+        self, start_date: str, end_date: str
+    ) -> dict | None:
+        """Fetch dashboard summary statistics.
+
+        Args:
+            start_date: Date in MM-DD-YYYY format
+            end_date: Date in MM-DD-YYYY format
+
+        Returns dict with averageReading, timeInUsePercent, etc. or None.
+        """
+        try:
+            user_guid = self.account_id or self.pumper_id
+            url = (
+                f"{self.urls['TDC_BASE']}tconnect/controliq/api/summary/"
+                f"users/{user_guid}?startDate={start_date}&endDate={end_date}"
+            )
+            return await self._api_get(url)
+        except (TandemApiError, httpx.HTTPError) as e:
+            _LOGGER.debug("Dashboard summary not available: %s", e)
+            return None
+
+    async def get_therapy_events(
+        self, start_date: str, end_date: str
+    ) -> dict | None:
+        """Fetch therapy events used by the webui Therapy Timeline.
+
+        Args:
+            start_date: Date in MM-DD-YYYY format
+            end_date: Date in MM-DD-YYYY format
+        """
+        try:
+            user_guid = self.account_id or self.pumper_id
+            url = (
+                f"{self.urls['TDC_BASE']}tconnect/therapyevents/api/"
+                f"TherapyEvents/{start_date}/{end_date}/false?userId={user_guid}"
+            )
+            return await self._api_get(url)
+        except (TandemApiError, httpx.HTTPError) as e:
+            _LOGGER.debug("Therapy events not available: %s", e)
+            return None
+
+    # ── Unified data fetch ───────────────────────────────────────────────
+
+    async def get_recent_data(self) -> dict:
+        """Fetch all available recent data from both Tandem Source and ControlIQ APIs.
+
+        Returns a unified dict with keys:
+            pump_metadata: dict or None
+            pumper_info: dict or None
+            therapy_timeline: dict or None
+            dashboard_summary: dict or None
+        """
+        data = {
+            "pump_metadata": None,
+            "pumper_info": None,
+            "therapy_timeline": None,
+            "dashboard_summary": None,
+        }
+
+        # Pump event metadata (Tandem Source API - should always work)
+        try:
+            metadata_list = await self.get_pump_event_metadata()
+            if metadata_list and isinstance(metadata_list, list) and len(metadata_list) > 0:
+                data["pump_metadata"] = metadata_list[0]
+            elif isinstance(metadata_list, dict):
+                data["pump_metadata"] = metadata_list
+        except Exception as e:
+            _LOGGER.warning("Failed to fetch pump metadata: %s", e)
+
+        # Pumper info (Tandem Source API - should always work)
+        try:
+            data["pumper_info"] = await self.get_pumper_info()
+        except Exception as e:
+            _LOGGER.warning("Failed to fetch pumper info: %s", e)
+
+        # Therapy timeline for last 1 day (ControlIQ API - may not work)
+        today = datetime.now()
+        yesterday = today - timedelta(days=1)
+        start = yesterday.strftime("%m-%d-%Y")
+        end = today.strftime("%m-%d-%Y")
+
+        data["therapy_timeline"] = await self.get_therapy_timeline(start, end)
+        data["dashboard_summary"] = await self.get_dashboard_summary(start, end)
+
+        return data
+
+    async def close(self):
+        """Close the HTTP client."""
+        if self._client and not self._client.is_closed:
+            await self._client.aclose()
+            self._client = None
+
+
+def parse_dotnet_date(date_str) -> datetime | None:
+    """Parse .NET /Date(epoch_ms)/ or /Date(epoch_ms+offset)/ format.
+
+    Also handles plain ISO 8601 date strings and epoch integers.
+    """
+    if date_str is None:
+        return None
+
+    if isinstance(date_str, (int, float)):
+        return datetime.fromtimestamp(date_str / 1000 if date_str > 1e12 else date_str)
+
+    if isinstance(date_str, str):
+        # .NET date format: /Date(1234567890000)/ or /Date(1234567890000+0000)/
+        match = re.match(r"/Date\((\d+)([+-]\d+)?\)/", date_str)
+        if match:
+            epoch_ms = int(match.group(1))
+            return datetime.fromtimestamp(epoch_ms / 1000)
+
+        # ISO 8601 format
+        try:
+            return datetime.fromisoformat(date_str.replace("Z", "+00:00")).replace(
+                tzinfo=None
+            )
+        except (ValueError, AttributeError):
+            pass
+
+    return None

--- a/custom_components/carelink/translations/en.json
+++ b/custom_components/carelink/translations/en.json
@@ -11,8 +11,15 @@
         },
         "step": {
             "user": {
+                "title": "Choose your pump platform",
+                "description": "Select the diabetes pump platform you want to connect.",
+                "data": {
+                    "platform_type": "Pump platform"
+                }
+            },
+            "carelink": {
                 "title": "Setup your Carelink account",
-                "description": "Run the external script to get the session information. These can be copied as a file into the Carelink Integration directory, or the values ??of the parameters can be entered into this mask. If you are logging in with a Carelink Care Partner account, please provide Patient ID. This should be the primary Carelink account username. The Scan Interval determines the number of seconds before the data is collected again.",
+                "description": "Run the external script to get the session information. These can be copied as a file into the Carelink Integration directory, or the values of the parameters can be entered into this mask. If you are logging in with a Carelink Care Partner account, please provide Patient ID. This should be the primary Carelink account username. The Scan Interval determines the number of seconds before the data is collected again.",
                 "data": {
                     "scan_interval": "Scan Interval in seconds (30-300)",
                     "cl_token": "Access Token (Optional)",
@@ -25,15 +32,27 @@
                     "nightscout_api": "Nightscout API Secret (Optional)"
                 }
             },
-		    "reconfigure": {
-                "title": "Reconfigure Carelink",
-                "description": "Update your Nightscout connection or scan interval.",
+            "tandem": {
+                "title": "Setup your Tandem Source account",
+                "description": "Enter your Tandem Diabetes Source account credentials. This connects to source.tandemdiabetes.com (US) or source.eu.tandemdiabetes.com (EU) to fetch data from your Tandem t:slim pump. The Scan Interval determines the number of seconds between data fetches (note: pump data may have a 30+ minute lag).",
                 "data": {
-                    "scan_interval": "Scan Interval in seconds (30-300)",
+                    "tandem_email": "Email Address",
+                    "tandem_password": "Password",
+                    "tandem_region": "Region",
+                    "scan_interval": "Scan Interval in seconds (60-900)",
                     "nightscout_url": "Nightscout URL (Optional)",
                     "nightscout_api": "Nightscout API Secret (Optional)"
                 }
-		    }
+            },
+            "reconfigure": {
+                "title": "Reconfigure integration",
+                "description": "Update your Nightscout connection or scan interval.",
+                "data": {
+                    "scan_interval": "Scan Interval in seconds",
+                    "nightscout_url": "Nightscout URL (Optional)",
+                    "nightscout_api": "Nightscout API Secret (Optional)"
+                }
+            }
         }
     }
 }

--- a/tests/test_config_flow.py
+++ b/tests/test_config_flow.py
@@ -6,14 +6,14 @@ import pytest
 from custom_components.carelink.config_flow import (
     CannotConnect,
     InvalidAuth,
-    validate_input,
+    validate_carelink_input,
 )
 
 
 class TestValidateInput:
-    """Tests for the validate_input function."""
+    """Tests for the validate_carelink_input function."""
 
-    async def test_validate_input_success(self):
+    async def test_validate_carelink_input_success(self):
         """Test successful validation."""
         mock_hass = MagicMock()
 
@@ -34,13 +34,13 @@ class TestValidateInput:
                 "patientId": "test_patient",
             }
 
-            result = await validate_input(mock_hass, data)
+            result = await validate_carelink_input(mock_hass, data)
 
             assert result == {"title": "Carelink"}
             mock_client.login.assert_called_once()
             mock_client.close.assert_called_once()
 
-    async def test_validate_input_invalid_auth(self):
+    async def test_validate_carelink_input_invalid_auth(self):
         """Test validation with invalid credentials."""
         mock_hass = MagicMock()
 
@@ -58,9 +58,9 @@ class TestValidateInput:
             }
 
             with pytest.raises(InvalidAuth):
-                await validate_input(mock_hass, data)
+                await validate_carelink_input(mock_hass, data)
 
-    async def test_validate_input_nightscout_success(self):
+    async def test_validate_carelink_input_nightscout_success(self):
         """Test validation with valid Nightscout configuration."""
         mock_hass = MagicMock()
 
@@ -86,12 +86,12 @@ class TestValidateInput:
                 "nightscout_api": "secret123",
             }
 
-            result = await validate_input(mock_hass, data)
+            result = await validate_carelink_input(mock_hass, data)
 
             assert result == {"title": "Carelink"}
             mock_uploader.reachServer.assert_called_once()
 
-    async def test_validate_input_nightscout_unreachable(self):
+    async def test_validate_carelink_input_nightscout_unreachable(self):
         """Test validation when Nightscout server is unreachable."""
         mock_hass = MagicMock()
 
@@ -118,9 +118,9 @@ class TestValidateInput:
             }
 
             with pytest.raises(CannotConnect):
-                await validate_input(mock_hass, data)
+                await validate_carelink_input(mock_hass, data)
 
-    async def test_validate_input_nightscout_url_only(self):
+    async def test_validate_carelink_input_nightscout_url_only(self):
         """Test validation fails when only URL is provided."""
         mock_hass = MagicMock()
 
@@ -140,9 +140,9 @@ class TestValidateInput:
             }
 
             with pytest.raises(CannotConnect):
-                await validate_input(mock_hass, data)
+                await validate_carelink_input(mock_hass, data)
 
-    async def test_validate_input_nightscout_api_only(self):
+    async def test_validate_carelink_input_nightscout_api_only(self):
         """Test validation fails when only API key is provided."""
         mock_hass = MagicMock()
 
@@ -162,9 +162,9 @@ class TestValidateInput:
             }
 
             with pytest.raises(CannotConnect):
-                await validate_input(mock_hass, data)
+                await validate_carelink_input(mock_hass, data)
 
-    async def test_validate_input_invalid_url_scheme(self):
+    async def test_validate_carelink_input_invalid_url_scheme(self):
         """Test validation fails with invalid URL scheme."""
         mock_hass = MagicMock()
 
@@ -184,9 +184,9 @@ class TestValidateInput:
             }
 
             with pytest.raises(CannotConnect):
-                await validate_input(mock_hass, data)
+                await validate_carelink_input(mock_hass, data)
 
-    async def test_validate_input_url_without_host(self):
+    async def test_validate_carelink_input_url_without_host(self):
         """Test validation fails with URL without host."""
         mock_hass = MagicMock()
 
@@ -206,9 +206,9 @@ class TestValidateInput:
             }
 
             with pytest.raises(CannotConnect):
-                await validate_input(mock_hass, data)
+                await validate_carelink_input(mock_hass, data)
 
-    async def test_validate_input_strips_url_whitespace(self):
+    async def test_validate_carelink_input_strips_url_whitespace(self):
         """Test that URL whitespace is stripped."""
         mock_hass = MagicMock()
 
@@ -234,7 +234,7 @@ class TestValidateInput:
                 "nightscout_api": "secret123",
             }
 
-            await validate_input(mock_hass, data)
+            await validate_carelink_input(mock_hass, data)
 
             # URL should be stripped
             assert data["nightscout_url"] == "https://nightscout.example.com"


### PR DESCRIPTION
<html>
<body>
<!--StartFragment--><html><head></head><body><p>Here are installation and configuration instructions for the Tandem t:slim integration:</p>
<hr>
<h1>Tandem t:slim Pump Integration for Home Assistant</h1>
<h2>Prerequisites</h2>
<ol>
<li><strong>A Tandem t:slim pump</strong> syncing data to <a href="https://source.eu.tandemdiabetes.com/">Tandem Source</a> (EU) or <a href="https://source.tandemdiabetes.com/">source.tandemdiabetes.com</a> (US)</li>
<li><strong>Home Assistant</strong> (2023.x or later)</li>
<li><strong>Tandem Source account credentials</strong> (email + password)</li>
</ol>
<h2>Installation</h2>
<h3>Method 1: HACS (Recommended)</h3>
<ol>
<li>Open <strong>HACS</strong> in Home Assistant</li>
<li>Go to <strong>Integrations</strong> &gt; <strong>3-dot menu</strong> &gt; <strong>Custom repositories</strong></li>
<li>Add repository URL: <code>https://github.com/jnctech/Home-Assistant-Carelink</code></li>
<li>Category: <strong>Integration</strong></li>
<li>Click <strong>Add</strong>, then find "Carelink" and click <strong>Download</strong></li>
<li>Restart Home Assistant</li>
</ol>
<h3>Method 2: Manual</h3>
<ol>
<li>Copy the <code>custom_components/carelink/</code> folder into your Home Assistant <code>config/custom_components/</code> directory:
<pre><code>config/└── custom_components/    └── carelink/        ├── __init__.py        ├── api.py        ├── tandem_api.py        ├── config_flow.py        ├── const.py        ├── sensor.py        ├── binary_sensor.py        ├── nightscout_uploader.py        ├── manifest.json        ├── strings.json        └── translations/            └── en.json
</code></pre></li>
<li>Restart Home Assistant</li>
</ol>
<h2>Configuration</h2>
<ol>
<li>Go to <strong>Settings</strong> &gt; <strong>Devices &amp; Services</strong> &gt; <strong>Add Integration</strong></li>
<li>Search for <strong>"Carelink"</strong></li>
<li>Select <strong>Tandem t:slim</strong> as the platform</li>
<li>Fill in:
<ul>
<li><strong>Email</strong>: Your Tandem Source account email</li>
<li><strong>Password</strong>: Your Tandem Source account password</li>
<li><strong>Region</strong>: <code>EU</code> or <code>US</code> (depending on your Tandem Source URL)</li>
<li><strong>Scan interval</strong>: Polling frequency in seconds (default: 300, range: 60–900)</li>
<li>Leave Nightscout fields blank (see below if you want Nightscout later)</li>
</ul>
</li>
<li>Click <strong>Submit</strong></li>
</ol>
<h2>Sensors Created</h2>
<p>Once configured, the integration creates these sensors:</p>

Sensor | Description
-- | --
Last SG (mmol/L) | Latest glucose reading in mmol/L
Last SG (mg/dL) | Latest glucose reading in mg/dL
SG Delta (mg/dL) | Change since previous reading
Active Insulin (IOB) | Insulin on board
Basal Rate | Current basal rate (U/hr)
Last Bolus Amount | Most recent bolus (units)
Last Bolus Time | Timestamp of most recent bolus
Last Bolus Type | Normal, Extended, or Automatic
Last Meal Bolus | Most recent meal bolus (units)
Last Meal Time | Timestamp of most recent meal bolus
Control-IQ Status | Current Control-IQ mode
Pump Battery | Battery level
Reservoir Level | Insulin remaining (units)
Pump Serial Number | Device serial
Average Reading | Average glucose (from dashboard)
Time in Range (%) | Percentage of time in target range
CGM Inactive (%) | Percentage of time CGM was inactive
Pump Model | Pump model name
Last Update | Timestamp of last data sync


<hr>
<h2>Optional: Nightscout Setup</h2>
<p>Nightscout provides a web dashboard for glucose data visualization and remote monitoring. If you want this, here are two options:</p>
<h3>Option A: Docker Compose (Standalone)</h3>
<ol>
<li>
<p>Create a directory for Nightscout:</p>
<pre><code class="language-bash">mkdir -p ~/nightscout &amp;&amp; cd ~/nightscout
</code></pre>
</li>
<li>
<p>Create <code>docker-compose.yml</code>:</p>
<pre><code class="language-yaml">version: '3.8'

services:
  mongo:
    image: mongo:4.4
    container_name: nightscout-mongo
    volumes:
      - mongo-data:/data/db
    restart: unless-stopped

  nightscout:
    image: nightscout/cgm-remote-monitor:latest
    container_name: nightscout
    depends_on:
      - mongo
    ports:
      - "1337:1337"
    environment:
      NODE_ENV: production
      TZ: Europe/Amsterdam          # &lt;-- your timezone
      MONGO_CONNECTION: mongodb://mongo:27017/nightscout
      API_SECRET: your-api-secret-min-12-chars   # &lt;-- change this!
      DISPLAY_UNITS: mmol                         # or "mg/dl"
      ENABLE: careportal basal iob cob cage sage pump openaps
      AUTH_DEFAULT_ROLES: readable
      BASE_URL: http://your-ha-ip:1337            # &lt;-- your HA server IP
    restart: unless-stopped

volumes:
  mongo-data:
</code></pre>
</li>
<li>
<p>Start it:</p>
<pre><code class="language-bash">docker compose up -d
</code></pre>
</li>
<li>
<p>Verify at <code>http://your-ha-ip:1337</code></p>
</li>
</ol>
<h3>Option B: Portainer</h3>
<ol>
<li>Open <strong>Portainer</strong> &gt; <strong>Stacks</strong> &gt; <strong>Add stack</strong></li>
<li>Name: <code>nightscout</code></li>
<li>Paste the same <code>docker-compose.yml</code> content from Option A above into the <strong>Web editor</strong></li>
<li>Update the environment values (timezone, API_SECRET, BASE_URL)</li>
<li>Click <strong>Deploy the stack</strong></li>
<li>Verify at <code>http://your-ha-ip:1337</code></li>
</ol>
<h3>Connecting Nightscout to the Integration</h3>
<p>Once Nightscout is running, reconfigure the integration:</p>
<ol>
<li>Go to <strong>Settings</strong> &gt; <strong>Devices &amp; Services</strong> &gt; <strong>Carelink</strong> &gt; <strong>Configure</strong></li>
<li>Enter:
<ul>
<li><strong>Nightscout URL</strong>: <code>http://your-ha-ip:1337</code> (or use the Docker hostname if HA runs in Docker too, e.g., <code>http://nightscout:1337</code>)</li>
<li><strong>Nightscout API Secret</strong>: The <code>API_SECRET</code> value from your Docker config</li>
</ul>
</li>
<li>Click <strong>Submit</strong></li>
</ol>
<p>The integration will then upload glucose data to Nightscout on each poll cycle.</p>
<h3>Important Notes for Nightscout</h3>
<ul>
<li><code>API_SECRET</code> must be at least 12 characters</li>
<li>If Home Assistant and Nightscout run on the same Docker network, use the container name (<code>http://nightscout:1337</code>) as the URL</li>
<li>For external access, set up a reverse proxy (e.g., Nginx Proxy Manager, Caddy, or Traefik) with HTTPS</li>
<li>Default Nightscout port is <code>1337</code> — change the left side of the port mapping if needed (e.g., <code>8080:1337</code>)</li>
</ul></body></html><!--EndFragment-->
</body>
</html>Here are installation and configuration instructions for the Tandem t:slim integration:

---

# Tandem t:slim Pump Integration for Home Assistant

## Prerequisites

1. **A Tandem t:slim pump** syncing data to [[Tandem Source](https://source.eu.tandemdiabetes.com/)](https://source.eu.tandemdiabetes.com) (EU) or [[source.tandemdiabetes.com](https://source.tandemdiabetes.com/)](https://source.tandemdiabetes.com) (US)
2. **Home Assistant** (2023.x or later)
3. **Tandem Source account credentials** (email + password)

## Installation

### Method 1: HACS (Recommended)

1. Open **HACS** in Home Assistant
2. Go to **Integrations** > **3-dot menu** > **Custom repositories**
3. Add repository URL: `https://github.com/jnctech/Home-Assistant-Carelink`
4. Category: **Integration**
5. Click **Add**, then find "Carelink" and click **Download**
6. Restart Home Assistant

### Method 2: Manual

1. Copy the `custom_components/carelink/` folder into your Home Assistant `config/custom_components/` directory:
   ```
   config/
   └── custom_components/
       └── carelink/
           ├── __init__.py
           ├── api.py
           ├── tandem_api.py
           ├── config_flow.py
           ├── const.py
           ├── sensor.py
           ├── binary_sensor.py
           ├── nightscout_uploader.py
           ├── manifest.json
           ├── strings.json
           └── translations/
               └── en.json
   ```
2. Restart Home Assistant

## Configuration

1. Go to **Settings** > **Devices & Services** > **Add Integration**
2. Search for **"Carelink"**
3. Select **Tandem t:slim** as the platform
4. Fill in:
   - **Email**: Your Tandem Source account email
   - **Password**: Your Tandem Source account password
   - **Region**: `EU` or `US` (depending on your Tandem Source URL)
   - **Scan interval**: Polling frequency in seconds (default: 300, range: 60–900)
   - Leave Nightscout fields blank (see below if you want Nightscout later)
5. Click **Submit**

## Sensors Created

Once configured, the integration creates these sensors:

| Sensor | Description |
|--------|-------------|
| Last SG (mmol/L) | Latest glucose reading in mmol/L |
| Last SG (mg/dL) | Latest glucose reading in mg/dL |
| SG Delta (mg/dL) | Change since previous reading |
| Active Insulin (IOB) | Insulin on board |
| Basal Rate | Current basal rate (U/hr) |
| Last Bolus Amount | Most recent bolus (units) |
| Last Bolus Time | Timestamp of most recent bolus |
| Last Bolus Type | Normal, Extended, or Automatic |
| Last Meal Bolus | Most recent meal bolus (units) |
| Last Meal Time | Timestamp of most recent meal bolus |
| Control-IQ Status | Current Control-IQ mode |
| Pump Battery | Battery level |
| Reservoir Level | Insulin remaining (units) |
| Pump Serial Number | Device serial |
| Average Reading | Average glucose (from dashboard) |
| Time in Range (%) | Percentage of time in target range |
| CGM Inactive (%) | Percentage of time CGM was inactive |
| Pump Model | Pump model name |
| Last Update | Timestamp of last data sync |

---

## Optional: Nightscout Setup

Nightscout provides a web dashboard for glucose data visualization and remote monitoring. If you want this, here are two options:

### Option A: Docker Compose (Standalone)

1. Create a directory for Nightscout:
   ```bash
   mkdir -p ~/nightscout && cd ~/nightscout
   ```

2. Create `docker-compose.yml`:
   ```yaml
   version: '3.8'

   services:
     mongo:
       image: mongo:4.4
       container_name: nightscout-mongo
       volumes:
         - mongo-data:/data/db
       restart: unless-stopped

     nightscout:
       image: nightscout/cgm-remote-monitor:latest
       container_name: nightscout
       depends_on:
         - mongo
       ports:
         - "1337:1337"
       environment:
         NODE_ENV: production
         TZ: Europe/Amsterdam          # <-- your timezone
         MONGO_CONNECTION: mongodb://mongo:27017/nightscout
         API_SECRET: your-api-secret-min-12-chars   # <-- change this!
         DISPLAY_UNITS: mmol                         # or "mg/dl"
         ENABLE: careportal basal iob cob cage sage pump openaps
         AUTH_DEFAULT_ROLES: readable
         BASE_URL: http://your-ha-ip:1337            # <-- your HA server IP
       restart: unless-stopped

   volumes:
     mongo-data:
   ```

3. Start it:
   ```bash
   docker compose up -d
   ```

4. Verify at `http://your-ha-ip:1337`

### Option B: Portainer

1. Open **Portainer** > **Stacks** > **Add stack**
2. Name: `nightscout`
3. Paste the same `docker-compose.yml` content from Option A above into the **Web editor**
4. Update the environment values (timezone, API_SECRET, BASE_URL)
5. Click **Deploy the stack**
6. Verify at `http://your-ha-ip:1337`

### Connecting Nightscout to the Integration

Once Nightscout is running, reconfigure the integration:

1. Go to **Settings** > **Devices & Services** > **Carelink** > **Configure**
2. Enter:
   - **Nightscout URL**: `http://your-ha-ip:1337` (or use the Docker hostname if HA runs in Docker too, e.g., `http://nightscout:1337`)
   - **Nightscout API Secret**: The `API_SECRET` value from your Docker config
3. Click **Submit**

The integration will then upload glucose data to Nightscout on each poll cycle.

### Important Notes for Nightscout

- `API_SECRET` must be at least 12 characters
- If Home Assistant and Nightscout run on the same Docker network, use the container name (`http://nightscout:1337`) as the URL
- For external access, set up a reverse proxy (e.g., Nginx Proxy Manager, Caddy, or Traefik) with HTTPS
- Default Nightscout port is `1337` — change the left side of the port mapping if needed (e.g., `8080:1337`)