### PR TITLE
fix: deduplicate Nightscout uploads to prevent doubled treatments

### DIFF
--- a/custom_components/carelink/__init__.py
+++ b/custom_components/carelink/__init__.py
@@ -205,7 +205,9 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     if config["nightscout_url"] and config["nightscout_api"]:
         nightscout_uploader = NightscoutUploader(
             config["nightscout_url"],
-            config["nightscout_api"]
+            config["nightscout_api"],
+            config_path=hass.config.path(),
+            entry_id=entry.entry_id
         )
         hass.data.setdefault(DOMAIN, {})[entry.entry_id].update({UPLOADER: nightscout_uploader})
 

--- a/custom_components/carelink/nightscout_uploader.py
+++ b/custom_components/carelink/nightscout_uploader.py
@@ -1,10 +1,12 @@
 import argparse
 import asyncio
-from datetime import datetime
+from datetime import datetime, timedelta, timezone
 import hashlib
 import json
 import logging
+import os
 
+import aiofiles
 import httpx
 
 from .const import (
@@ -12,6 +14,7 @@ from .const import (
 )
 
 NS_USER_AGENT= "Home Assistant Carelink"
+DEDUP_RETENTION_HOURS = 25
 DEBUG = False
 
 _LOGGER = logging.getLogger(__name__)
@@ -30,7 +33,9 @@ class NightscoutUploader:
     def __init__(
         self,
         nightscout_url,
-        nightscout_secret
+        nightscout_secret,
+        config_path=None,
+        entry_id=None
     ):
 
         # Nightscout info
@@ -47,6 +52,22 @@ class NightscoutUploader:
             'Accept': 'application/json',
         }
 
+        # Deduplication state
+        if config_path and entry_id:
+            self._dedup_file_path = os.path.join(
+                config_path, f"carelink_ns_dedup_{entry_id}.json"
+            )
+        elif config_path or entry_id:
+            _LOGGER.warning(
+                "Deduplication disabled: both config_path and entry_id are required, "
+                "got config_path=%s, entry_id=%s", config_path, entry_id
+            )
+            self._dedup_file_path = None
+        else:
+            self._dedup_file_path = None
+        self._seen_fingerprints: dict[str, str] = {}
+        self._dedup_loaded = False
+
     @property
     def async_client(self):
         """Return the httpx client."""
@@ -60,6 +81,71 @@ class NightscoutUploader:
         if self._async_client:
             await self._async_client.aclose()
             self._async_client = None
+
+    @staticmethod
+    def _compute_fingerprint(entry, data_type):
+        """Compute a SHA-256 fingerprint for deduplication.
+
+        Returns None for data types that should always be uploaded (devicestatus).
+        """
+        if data_type == "devicestatus":
+            return None
+
+        if data_type == "treatments":
+            key_fields = (
+                str(entry.get("eventType", "")),
+                str(entry.get("created_at", "")),
+                str(entry.get("carbs", "")),
+                str(entry.get("insulin", "")),
+                str(entry.get("absolute", "")),
+                str(entry.get("notes", "")),
+                str(entry.get("glucose", "")),
+            )
+        elif data_type == "entries":
+            key_fields = (
+                str(entry.get("type", "")),
+                str(entry.get("dateString", "")),
+                str(entry.get("sgv", "")),
+            )
+        else:
+            return None
+
+        raw = "|".join(key_fields)
+        return hashlib.sha256(raw.encode("utf-8")).hexdigest()
+
+    async def _load_dedup_state(self):
+        """Load dedup state from disk (once per uploader lifetime)."""
+        if self._dedup_loaded or not self._dedup_file_path:
+            return
+        try:
+            async with aiofiles.open(self._dedup_file_path, mode="r") as f:
+                self._seen_fingerprints = json.loads(await f.read())
+        except FileNotFoundError:
+            self._seen_fingerprints = {}
+        except (json.JSONDecodeError, OSError) as error:
+            _LOGGER.warning("Failed to load dedup state, starting fresh: %s", error)
+            self._seen_fingerprints = {}
+        self._dedup_loaded = True
+
+    async def _save_dedup_state(self):
+        """Persist dedup state to disk atomically."""
+        if not self._dedup_file_path:
+            return
+        tmp_path = self._dedup_file_path + ".tmp"
+        try:
+            async with aiofiles.open(tmp_path, mode="w") as f:
+                await f.write(json.dumps(self._seen_fingerprints))
+            os.replace(tmp_path, self._dedup_file_path)
+        except OSError as error:
+            _LOGGER.warning("Failed to save dedup state: %s", error)
+
+    def _purge_old_fingerprints(self):
+        """Remove fingerprints older than DEDUP_RETENTION_HOURS."""
+        cutoff = datetime.now(timezone.utc) - timedelta(hours=DEDUP_RETENTION_HOURS)
+        self._seen_fingerprints = {
+            fp: ts for fp, ts in self._seen_fingerprints.items()
+            if datetime.fromisoformat(ts) > cutoff
+        }
 
     async def fetch_async(self, url, headers, params=None):
         """Perform an async get request."""
@@ -227,11 +313,22 @@ class NightscoutUploader:
             return False
         success = True
         url = f"{host}/api/v1/{data_type}"
+        skipped = 0
+        uploaded = 0
         try:
             for entry in data:
+                fingerprint = self._compute_fingerprint(entry, data_type)
+                if fingerprint and fingerprint in self._seen_fingerprints:
+                    skipped += 1
+                    continue
+
                 response = await self.post_async(url, headers=self.__common_headers, data=json.dumps(entry))
                 if not response.status_code == 200:
                     raise ValueError("__set_data() session response is not OK " + str(response.status_code))
+
+                uploaded += 1
+                if fingerprint:
+                    self._seen_fingerprints[fingerprint] = datetime.now(timezone.utc).isoformat()
         except httpx.TimeoutException as error:
             printdbg(f"__set_data() failed: request timeout - {error}")
             success = False
@@ -241,6 +338,7 @@ class NightscoutUploader:
         except ValueError as error:
             printdbg(f"__set_data() failed: {error}")
             success = False
+        printdbg(f"__set_data() {data_type}: uploaded={uploaded}, skipped={skipped}")
         return success
 
     def __getMsgs(self, rawdata, tz):
@@ -458,7 +556,10 @@ class NightscoutUploader:
         self, recent_data, timezone
     ):
         printdbg("__send_recent_data()")
+        await self._load_dedup_state()
+        self._purge_old_fingerprints()
         await self.__slice_recent_data_for_transmission(recent_data, timezone)
+        await self._save_dedup_state()
 
     async def __test_server_connection(self):
         url = f"{self.__nightscout_url}/api/v1/devicestatus.json"

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -176,10 +176,12 @@ def mock_carelink_client(mock_token_data: dict[str, str], tmp_path) -> CarelinkC
 
 
 @pytest.fixture
-def mock_nightscout_uploader() -> NightscoutUploader:
+def mock_nightscout_uploader(tmp_path) -> NightscoutUploader:
     """Return a NightscoutUploader instance for testing."""
     uploader = NightscoutUploader(
         nightscout_url="https://nightscout.example.com",
         nightscout_secret="mock_api_secret",
+        config_path=str(tmp_path),
+        entry_id="test_entry",
     )
     return uploader

--- a/tests/test_nightscout_uploader.py
+++ b/tests/test_nightscout_uploader.py
@@ -1,5 +1,7 @@
 """Tests for the Nightscout uploader."""
-from datetime import datetime
+import json
+import os
+from datetime import datetime, timedelta, timezone
 from unittest.mock import AsyncMock, MagicMock, patch
 from zoneinfo import ZoneInfo
 
@@ -346,3 +348,223 @@ class TestNightscoutDataTransformation:
             "BC_MESSAGE_ANOTHER_TEST"
         )
         assert result == "ANOTHER_TEST"
+
+
+class TestNightscoutDeduplication:
+    """Tests for deduplication logic."""
+
+    def test_fingerprint_same_treatment_is_stable(self):
+        """Same treatment data produces the same fingerprint."""
+        entry = {
+            "eventType": "Meal",
+            "created_at": "2024-01-15T12:00:00+01:00",
+            "carbs": 45,
+            "insulin": 3.5,
+        }
+        fp1 = NightscoutUploader._compute_fingerprint(entry, "treatments")
+        fp2 = NightscoutUploader._compute_fingerprint(entry, "treatments")
+        assert fp1 == fp2
+        assert len(fp1) == 64  # SHA-256 hex length
+
+    def test_fingerprint_different_treatments(self):
+        """Different treatment data produces different fingerprints."""
+        entry_a = {
+            "eventType": "Meal",
+            "created_at": "2024-01-15T12:00:00+01:00",
+            "carbs": 45,
+            "insulin": 3.5,
+        }
+        entry_b = {
+            "eventType": "Meal",
+            "created_at": "2024-01-15T13:00:00+01:00",
+            "carbs": 30,
+            "insulin": 2.0,
+        }
+        fp_a = NightscoutUploader._compute_fingerprint(entry_a, "treatments")
+        fp_b = NightscoutUploader._compute_fingerprint(entry_b, "treatments")
+        assert fp_a != fp_b
+
+    def test_fingerprint_same_entry_is_stable(self):
+        """Same SGS entry data produces the same fingerprint."""
+        entry = {
+            "type": "sgv",
+            "dateString": "2024-01-15T12:00:00+01:00",
+            "sgv": 120.0,
+        }
+        fp1 = NightscoutUploader._compute_fingerprint(entry, "entries")
+        fp2 = NightscoutUploader._compute_fingerprint(entry, "entries")
+        assert fp1 == fp2
+        assert len(fp1) == 64
+
+    def test_fingerprint_different_entries(self):
+        """Different SGS entry data produces different fingerprints."""
+        entry_a = {
+            "type": "sgv",
+            "dateString": "2024-01-15T12:00:00+01:00",
+            "sgv": 120.0,
+        }
+        entry_b = {
+            "type": "sgv",
+            "dateString": "2024-01-15T12:05:00+01:00",
+            "sgv": 125.0,
+        }
+        fp_a = NightscoutUploader._compute_fingerprint(entry_a, "entries")
+        fp_b = NightscoutUploader._compute_fingerprint(entry_b, "entries")
+        assert fp_a != fp_b
+
+    def test_devicestatus_not_deduplicated(self):
+        """Devicestatus entries should not produce a fingerprint."""
+        entry = {"device": "MMT-1780", "pump": {"battery": {"status": "OK"}}}
+        fp = NightscoutUploader._compute_fingerprint(entry, "devicestatus")
+        assert fp is None
+
+    async def test_duplicate_entries_not_uploaded(self, mock_nightscout_uploader):
+        """POST is only called once per unique entry, duplicates are skipped."""
+        mock_response = MagicMock()
+        mock_response.status_code = 200
+
+        with patch.object(
+            mock_nightscout_uploader, "post_async", new_callable=AsyncMock
+        ) as mock_post:
+            mock_post.return_value = mock_response
+
+            treatment = {
+                "eventType": "Meal",
+                "created_at": "2024-01-15T12:00:00+01:00",
+                "carbs": 45,
+                "insulin": 3.5,
+            }
+
+            # First call: should upload
+            result = await mock_nightscout_uploader._NightscoutUploader__set_data(
+                "https://nightscout.example.com", [treatment], "treatments"
+            )
+            assert result is True
+            assert mock_post.call_count == 1
+
+            # Second call with same data: should skip
+            result = await mock_nightscout_uploader._NightscoutUploader__set_data(
+                "https://nightscout.example.com", [treatment], "treatments"
+            )
+            assert result is True
+            # Still only 1 call - duplicate was skipped
+            assert mock_post.call_count == 1
+
+    async def test_failed_upload_allows_retry(self, mock_nightscout_uploader):
+        """If POST fails, the fingerprint is not stored so retry is possible."""
+        mock_response_fail = MagicMock()
+        mock_response_fail.status_code = 500
+
+        mock_response_ok = MagicMock()
+        mock_response_ok.status_code = 200
+
+        treatment = {
+            "eventType": "Correction Bolus",
+            "created_at": "2024-01-15T14:00:00+01:00",
+            "insulin": 1.0,
+        }
+
+        with patch.object(
+            mock_nightscout_uploader, "post_async", new_callable=AsyncMock
+        ) as mock_post:
+            # First attempt fails
+            mock_post.return_value = mock_response_fail
+            result = await mock_nightscout_uploader._NightscoutUploader__set_data(
+                "https://nightscout.example.com", [treatment], "treatments"
+            )
+            assert result is False
+
+            # Fingerprint should NOT be in seen set
+            fp = NightscoutUploader._compute_fingerprint(treatment, "treatments")
+            assert fp not in mock_nightscout_uploader._seen_fingerprints
+
+            # Retry succeeds
+            mock_post.return_value = mock_response_ok
+            result = await mock_nightscout_uploader._NightscoutUploader__set_data(
+                "https://nightscout.example.com", [treatment], "treatments"
+            )
+            assert result is True
+            assert fp in mock_nightscout_uploader._seen_fingerprints
+
+    async def test_dedup_persists_to_file(self, tmp_path):
+        """A new uploader instance reads previously saved dedup state."""
+        uploader1 = NightscoutUploader(
+            nightscout_url="https://test.com",
+            nightscout_secret="secret",
+            config_path=str(tmp_path),
+            entry_id="persist_test",
+        )
+
+        # Simulate a seen fingerprint and save
+        uploader1._seen_fingerprints["abc123"] = datetime.now(timezone.utc).isoformat()
+        await uploader1._save_dedup_state()
+
+        # New instance should load the saved state
+        uploader2 = NightscoutUploader(
+            nightscout_url="https://test.com",
+            nightscout_secret="secret",
+            config_path=str(tmp_path),
+            entry_id="persist_test",
+        )
+        await uploader2._load_dedup_state()
+        assert "abc123" in uploader2._seen_fingerprints
+
+    async def test_purge_removes_old_fingerprints(self, mock_nightscout_uploader):
+        """Fingerprints older than 25 hours are removed by purge."""
+        now = datetime.now(timezone.utc)
+        old_ts = (now - timedelta(hours=26)).isoformat()
+        recent_ts = (now - timedelta(hours=1)).isoformat()
+
+        mock_nightscout_uploader._seen_fingerprints = {
+            "old_fp": old_ts,
+            "recent_fp": recent_ts,
+        }
+
+        mock_nightscout_uploader._purge_old_fingerprints()
+
+        assert "old_fp" not in mock_nightscout_uploader._seen_fingerprints
+        assert "recent_fp" in mock_nightscout_uploader._seen_fingerprints
+
+    def test_unknown_data_type_returns_none(self):
+        """Unknown data types should return None (no deduplication)."""
+        entry = {"foo": "bar"}
+        fp = NightscoutUploader._compute_fingerprint(entry, "unknown_type")
+        assert fp is None
+
+    async def test_load_handles_corrupted_json(self, tmp_path):
+        """Corrupted JSON in dedup file falls back to empty dict."""
+        uploader = NightscoutUploader(
+            nightscout_url="https://test.com",
+            nightscout_secret="secret",
+            config_path=str(tmp_path),
+            entry_id="corrupt_test",
+        )
+        # Write invalid JSON to the dedup file
+        dedup_file = os.path.join(str(tmp_path), "carelink_ns_dedup_corrupt_test.json")
+        with open(dedup_file, "w") as f:
+            f.write("{not valid json")
+
+        await uploader._load_dedup_state()
+
+        assert uploader._seen_fingerprints == {}
+        assert uploader._dedup_loaded is True
+
+    async def test_load_idempotency(self, tmp_path):
+        """Second call to _load_dedup_state does not overwrite in-memory changes."""
+        uploader = NightscoutUploader(
+            nightscout_url="https://test.com",
+            nightscout_secret="secret",
+            config_path=str(tmp_path),
+            entry_id="idempotent_test",
+        )
+
+        # First load (no file exists, starts empty)
+        await uploader._load_dedup_state()
+        assert uploader._seen_fingerprints == {}
+
+        # Add a fingerprint in memory
+        uploader._seen_fingerprints["new_fp"] = datetime.now(timezone.utc).isoformat()
+
+        # Second load should be a no-op (guard by _dedup_loaded)
+        await uploader._load_dedup_state()
+        assert "new_fp" in uploader._seen_fingerprints


### PR DESCRIPTION
## Summary

Fixes #150 — The Nightscout uploader was re-uploading ALL treatments from the 24-hour Carelink window on every polling cycle (default 60s), causing every meal, bolus, correction etc. to appear multiple times in Nightscout.

- Add file-based SHA-256 fingerprint deduplication to `NightscoutUploader`
- Fingerprints are computed from key fields per data type (`treatments`: eventType, created_at, carbs, insulin, absolute, notes, glucose; `entries`: type, dateString, sgv)
- `devicestatus` is always uploaded (no dedup — represents current pump state)
- Fingerprints are only recorded after successful HTTP 200, allowing retry on failure
- State persists to `{config_path}/carelink_ns_dedup_{entry_id}.json`, surviving HA restarts
- Atomic file writes (tmp + `os.replace`) prevent corruption on crash
- Fingerprints older than 25 hours are automatically purged each cycle
- Warning logged when dedup params are partially configured
