### PR TITLE
fix: move httpx.AsyncClient creation off event loop (#153)

### DIFF
--- a/custom_components/carelink/api.py
+++ b/custom_components/carelink/api.py
@@ -111,11 +111,10 @@ class CarelinkClient:
                 "User-Agent": "Dalvik/2.1.0 (Linux; U; Android 10; Nexus 5X Build/QQ3A.200805.001)",
                 }
 
-    @property
-    def async_client(self):
+    async def async_client(self):
         """Return the httpx client."""
         if not self._async_client:
-            self._async_client = httpx.AsyncClient()
+            self._async_client = await asyncio.to_thread(httpx.AsyncClient)
         return self._async_client
 
     async def close(self):
@@ -126,7 +125,8 @@ class CarelinkClient:
 
     async def fetch_async(self, url, headers, params=None):
         """Perform an async get request."""
-        response = await self.async_client.get(
+        client = await self.async_client()
+        response = await client.get(
             url,
             headers=headers,
             params=params,
@@ -137,7 +137,8 @@ class CarelinkClient:
 
     async def post_async(self, url, headers, data=None, params=None):
         """Perform an async post request."""
-        response = await self.async_client.post(
+        client = await self.async_client()
+        response = await client.post(
             url,
             headers=headers,
             params=params,

--- a/custom_components/carelink/nightscout_uploader.py
+++ b/custom_components/carelink/nightscout_uploader.py
@@ -68,11 +68,10 @@ class NightscoutUploader:
         self._seen_fingerprints: dict[str, str] = {}
         self._dedup_loaded = False
 
-    @property
-    def async_client(self):
+    async def async_client(self):
         """Return the httpx client."""
         if not self._async_client:
-            self._async_client = httpx.AsyncClient()
+            self._async_client = await asyncio.to_thread(httpx.AsyncClient)
 
         return self._async_client
 
@@ -149,7 +148,8 @@ class NightscoutUploader:
 
     async def fetch_async(self, url, headers, params=None):
         """Perform an async get request."""
-        response = await self.async_client.get(
+        client = await self.async_client()
+        response = await client.get(
             url,
             headers=headers,
             params=params,
@@ -160,7 +160,8 @@ class NightscoutUploader:
 
     async def post_async(self, url, headers, data=None, params=None):
         """Perform an async post request."""
-        response = await self.async_client.post(
+        client = await self.async_client()
+        response = await client.post(
             url,
             headers=headers,
             params=params,

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -16,17 +16,17 @@ class TestCarelinkClient:
         assert mock_carelink_client is not None
         assert mock_carelink_client._async_client is None
 
-    def test_async_client_property(self, mock_carelink_client):
-        """Test async_client property creates client on first access."""
-        client = mock_carelink_client.async_client
+    async def test_async_client_method(self, mock_carelink_client):
+        """Test async_client method creates client on first access."""
+        client = await mock_carelink_client.async_client()
         assert client is not None
         # Second access should return same client
-        assert mock_carelink_client.async_client is client
+        assert await mock_carelink_client.async_client() is client
 
     async def test_close(self, mock_carelink_client):
         """Test closing the HTTP client."""
         # Create client first
-        _ = mock_carelink_client.async_client
+        _ = await mock_carelink_client.async_client()
         assert mock_carelink_client._async_client is not None
 
         # Close it

--- a/tests/test_nightscout_uploader.py
+++ b/tests/test_nightscout_uploader.py
@@ -42,17 +42,17 @@ class TestNightscoutUploaderInit:
 class TestNightscoutUploaderClient:
     """Tests for HTTP client management."""
 
-    def test_async_client_property(self, mock_nightscout_uploader):
-        """Test async_client property creates client on first access."""
-        client = mock_nightscout_uploader.async_client
+    async def test_async_client_method(self, mock_nightscout_uploader):
+        """Test async_client method creates client on first access."""
+        client = await mock_nightscout_uploader.async_client()
         assert client is not None
         # Second access should return same client
-        assert mock_nightscout_uploader.async_client is client
+        assert await mock_nightscout_uploader.async_client() is client
 
     async def test_close(self, mock_nightscout_uploader):
         """Test closing the HTTP client."""
         # Create client first
-        _ = mock_nightscout_uploader.async_client
+        _ = await mock_nightscout_uploader.async_client()
         assert mock_nightscout_uploader._async_client is not None
 
         # Close it


### PR DESCRIPTION
## Summary
- Fixes #153 — `load_verify_locations` blocking call error on startup
- `httpx.AsyncClient()` internally calls `ssl.SSLContext.load_verify_locations()` which is a blocking I/O operation that Home Assistant detects and flags
- Changed `async_client` from a synchronous property to an async method that creates the client via `asyncio.to_thread()`, moving the blocking SSL initialization off the event loop
